### PR TITLE
Zero-copy FFI payload pipeline, cridecoder 0.3.4, and pipeline cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,6 +1109,7 @@ dependencies = [
 name = "haruki-assetstudio-ffi"
 version = "6.0.5"
 dependencies = [
+ "bytes",
  "clap",
  "libc",
  "libloading 0.9.0",
@@ -1126,6 +1127,7 @@ version = "6.0.5"
 dependencies = [
  "aes 0.9.1",
  "axum",
+ "bytes",
  "cbc 0.2.1",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "cridecoder"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afbd29544b4195fb7fda71189d9dc7efe8f4fc376b4a2f8eb8aaa52e9ecc18e"
+checksum = "791e2f16c14800658903e329013a208a7dfe9bf9f9481140a4ac91df06cbc5fc"
 dependencies = [
  "byteorder",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ resolver = "2"
 [dependencies]
 aes = "0.9"
 axum = { version = "0.8", features = ["macros", "json"] }
+bytes = "1"
 cbc = { version = "0.2", features = ["alloc"] }
 chrono = { version = "0.4", features = ["clock", "serde"] }
 clap = { version = "4.6", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bytes = "1"
 cbc = { version = "0.2", features = ["alloc"] }
 chrono = { version = "0.4", features = ["clock", "serde"] }
 clap = { version = "4.6", features = ["derive"] }
-cridecoder = "0.3.3"
+cridecoder = "0.3.4"
 haruki-assetstudio-ffi = { path = "crates/assetstudio-ffi" }
 hex = "0.4"
 image = { version = "0.25", default-features = false, features = ["bmp", "jpeg", "png", "webp"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,9 @@ RUN cargo build --release --locked \
     -p haruki-assetstudio-ffi \
     --features haruki-sekai-asset-updater/media-ffi
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS assetstudio-builder
+# sdk:10.0 is Ubuntu noble (glibc 2.39); the runtime stage is Debian trixie
+# (glibc 2.41), so NativeAOT output built here loads there.
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS assetstudio-builder
 ARG TARGETARCH
 WORKDIR /src
 ARG ASSETSTUDIO_REPOSITORY=https://github.com/Team-Haruki/AssetStudio.git
@@ -56,8 +58,8 @@ RUN cd AssetStudio/AssetStudioFFI && \
         arm64) runtime_id=linux-arm64 ;; \
         *) echo "Unsupported Docker target architecture: ${TARGETARCH}" >&2; exit 1 ;; \
     esac && \
-    dotnet publish -c Release -r "${runtime_id}" -f net9.0 --self-contained true -o /app/assetstudio-ffi \
-    -p:TargetFrameworks=net9.0 \
+    dotnet publish -c Release -r "${runtime_id}" -f net10.0 --self-contained true -o /app/assetstudio-ffi \
+    -p:TargetFrameworks=net10.0 \
     -p:PublishAot=true \
     -p:InvariantGlobalization=true
 

--- a/README.md
+++ b/README.md
@@ -140,10 +140,9 @@ You can also download the standalone AssetStudioFFI archive or build the
   `HARUKI_ASSET_STUDIO_FFI_PROCESS_CONCURRENCY`,
   `HARUKI_ASSET_STUDIO_FFI_WORKER_MAX_CALLS`, and
   `HARUKI_ASSET_STUDIO_FFI_READ_BATCH_SIZE` tune worker pool throughput.
-- `backends.asset_studio.mode` defaults to `worker_pool` for production crash
-  isolation. Set it to `direct`, or set `HARUKI_ASSET_STUDIO_FFI_MODE=direct`,
-  only for local throughput benchmarks where the service process may load and
-  call `HarukiAssetStudioFFI` directly.
+- `backends.asset_studio.mode` is always `worker_pool` for production crash
+  isolation. The former in-process `direct` mode was removed; configuring it
+  fails config loading with a clear error.
 - `resources.memory.max_in_flight_bundle_bytes` is a soft memory guard. The default
   `0` disables it. On small Linux hosts, set it to the amount of bundle work the
   process may keep in memory, for example

--- a/crates/assetstudio-ffi/Cargo.toml
+++ b/crates/assetstudio-ffi/Cargo.toml
@@ -6,6 +6,7 @@ description = "AssetStudio FFI worker and typed ABI support for Haruki Sekai Ass
 license = "MIT"
 
 [dependencies]
+bytes = "1"
 clap = { version = "4.6", features = ["derive"] }
 libc = "0.2"
 libloading = "0.9"

--- a/crates/assetstudio-ffi/src/bin/assetstudio_ffi_worker.rs
+++ b/crates/assetstudio-ffi/src/bin/assetstudio_ffi_worker.rs
@@ -2,8 +2,9 @@ use std::io::Write;
 use std::io::{self, Read};
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{self, ExitCode};
+use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use clap::Parser;
@@ -14,7 +15,11 @@ use haruki_assetstudio_ffi::{
 use serde::{Deserialize, Serialize};
 
 const MAX_FRAME_SIZE: u64 = 256 * 1024 * 1024;
-const PAYLOAD_FILE_THRESHOLD: usize = 128 * 1024 * 1024;
+// Payloads above the threshold are spilled to a file (preferably tmpfs) instead of
+// being streamed through the stdout pipe; the parent maps the file zero-copy. The
+// pipe costs one write plus one read copy per payload, so keep only small payloads
+// (typetree/text batches) inline.
+const DEFAULT_PAYLOAD_FILE_THRESHOLD: usize = 8 * 1024 * 1024;
 const FFI_CALL_STACK_SIZE: usize = 64 * 1024 * 1024;
 
 #[derive(Debug, Parser)]
@@ -207,7 +212,7 @@ fn server_response_with_payload(
     payload: Vec<u8>,
 ) -> io::Result<ServerResponseWithPayload> {
     let payload_len = payload.len();
-    if payload_len > PAYLOAD_FILE_THRESHOLD {
+    if payload_len > payload_file_threshold() {
         let payload_file = spill_payload_to_temp_file(&payload)?;
         Ok(ServerResponse {
             id,
@@ -231,11 +236,65 @@ fn server_response_with_payload(
     }
 }
 
+fn payload_file_threshold() -> usize {
+    static THRESHOLD: OnceLock<usize> = OnceLock::new();
+    *THRESHOLD.get_or_init(|| {
+        std::env::var("HARUKI_ASSET_STUDIO_FFI_PAYLOAD_FILE_THRESHOLD")
+            .ok()
+            .and_then(|value| value.trim().parse().ok())
+            .unwrap_or(DEFAULT_PAYLOAD_FILE_THRESHOLD)
+    })
+}
+
+/// Preferred spill directory: explicit override, else tmpfs on Linux so the parent's
+/// mmap never touches disk. `None` falls back to the system temp directory.
+fn payload_spill_dir() -> Option<PathBuf> {
+    static DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
+    DIR.get_or_init(|| {
+        if let Ok(dir) = std::env::var("HARUKI_ASSET_STUDIO_FFI_PAYLOAD_DIR") {
+            let dir = PathBuf::from(dir.trim());
+            if !dir.as_os_str().is_empty() && dir.is_dir() {
+                return Some(dir);
+            }
+        }
+        #[cfg(target_os = "linux")]
+        {
+            let shm = PathBuf::from("/dev/shm");
+            if shm.is_dir() {
+                return Some(shm);
+            }
+        }
+        None
+    })
+    .clone()
+}
+
 fn spill_payload_to_temp_file(payload: &[u8]) -> io::Result<PathBuf> {
-    let mut file = tempfile::Builder::new()
+    if let Some(dir) = payload_spill_dir() {
+        match spill_payload_into_dir(payload, Some(&dir)) {
+            Ok(path) => return Ok(path),
+            Err(error) => {
+                // tmpfs may be smaller than the payload (e.g. a container's default
+                // /dev/shm); fall back to the system temp directory.
+                write_process_trace(
+                    "server_payload_spill_dir_fallback",
+                    &format!("dir={} error={error}", dir.display()),
+                );
+            }
+        }
+    }
+    spill_payload_into_dir(payload, None)
+}
+
+fn spill_payload_into_dir(payload: &[u8], dir: Option<&Path>) -> io::Result<PathBuf> {
+    let mut builder = tempfile::Builder::new();
+    builder
         .prefix("haruki-assetstudio-worker-payload-")
-        .suffix(".bin")
-        .tempfile()?;
+        .suffix(".bin");
+    let mut file = match dir {
+        Some(dir) => builder.tempfile_in(dir)?,
+        None => builder.tempfile()?,
+    };
     file.write_all(payload)?;
     file.flush()?;
     let temp_path = file.into_temp_path();
@@ -454,7 +513,10 @@ fn now_ms() -> u128 {
 mod tests {
     use std::io::{self, Cursor};
 
-    use super::{read_frame, spill_payload_to_temp_file, write_frame, MAX_FRAME_SIZE};
+    use super::{
+        read_frame, spill_payload_into_dir, spill_payload_to_temp_file, write_frame,
+        MAX_FRAME_SIZE,
+    };
 
     #[test]
     fn server_frame_round_trips_payload() {
@@ -491,6 +553,18 @@ mod tests {
 
         let payload_file = spill_payload_to_temp_file(payload).unwrap();
 
+        assert_eq!(std::fs::read(&payload_file).unwrap(), payload);
+        std::fs::remove_file(&payload_file).unwrap();
+    }
+
+    #[test]
+    fn server_payload_spill_uses_explicit_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let payload = b"directed-payload";
+
+        let payload_file = spill_payload_into_dir(payload, Some(dir.path())).unwrap();
+
+        assert_eq!(payload_file.parent(), Some(dir.path()));
         assert_eq!(std::fs::read(&payload_file).unwrap(), payload);
         std::fs::remove_file(&payload_file).unwrap();
     }

--- a/crates/assetstudio-ffi/src/bin/assetstudio_ffi_worker.rs
+++ b/crates/assetstudio-ffi/src/bin/assetstudio_ffi_worker.rs
@@ -5,12 +5,13 @@ use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::{self, ExitCode};
 use std::sync::OnceLock;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use clap::Parser;
 use haruki_assetstudio_ffi::{
     AssetStudioFfiError, AssetStudioFfiOperation, AssetStudioFfiRequest, AssetStudioFfiResponse,
-    LoadedAssetStudioFfiLibrary,
+    CallPayload, LoadedAssetStudioFfiLibrary, PayloadSpillPlan, WORKER_PAYLOAD_FILE_PREFIX,
+    WORKER_PAYLOAD_FILE_SUFFIX,
 };
 use serde::{Deserialize, Serialize};
 
@@ -80,8 +81,58 @@ struct ServerResponse {
     error: Option<String>,
 }
 
+// A live spill file only exists between the worker writing it and the parent
+// mapping + unlinking it — seconds at most. Anything this old in the spill
+// directories is a leak from a crashed worker (RAM on tmpfs), not in-flight work.
+const STALE_SPILL_FILE_MAX_AGE: Duration = Duration::from_secs(300);
+
+fn sweep_stale_spill_files() {
+    let mut directories = vec![std::env::temp_dir()];
+    if let Some(dir) = payload_spill_dir() {
+        if !directories.contains(&dir) {
+            directories.push(dir);
+        }
+    }
+    for directory in directories {
+        let removed = sweep_stale_spill_files_in(&directory, STALE_SPILL_FILE_MAX_AGE);
+        if removed > 0 {
+            write_process_trace(
+                "server_stale_spill_files_removed",
+                &format!("dir={} count={removed}", directory.display()),
+            );
+        }
+    }
+}
+
+fn sweep_stale_spill_files_in(directory: &Path, max_age: Duration) -> usize {
+    let Ok(entries) = std::fs::read_dir(directory) else {
+        return 0;
+    };
+    let mut removed = 0;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with(WORKER_PAYLOAD_FILE_PREFIX)
+            || !name.ends_with(WORKER_PAYLOAD_FILE_SUFFIX)
+        {
+            continue;
+        }
+        let stale = entry
+            .metadata()
+            .ok()
+            .and_then(|metadata| metadata.modified().ok())
+            .and_then(|modified| modified.elapsed().ok())
+            .is_some_and(|age| age > max_age);
+        if stale && std::fs::remove_file(entry.path()).is_ok() {
+            removed += 1;
+        }
+    }
+    removed
+}
+
 fn run_server(ffi_library: &str) -> ExitCode {
     write_process_trace("server_start", ffi_library);
+    sweep_stale_spill_files();
     let library = match LoadedAssetStudioFfiLibrary::load(ffi_library) {
         Ok(library) => library,
         Err(error) => {
@@ -121,18 +172,22 @@ fn run_server(ffi_library: &str) -> ExitCode {
         );
         let response = match call_native_with_stdout_suppressed(&library, &request.request) {
             Ok((status, response_body, payload)) => {
+                let payload_bytes = match &payload {
+                    CallPayload::Inline(bytes) => bytes.len() as u64,
+                    CallPayload::File { len, .. } => *len,
+                };
                 write_worker_trace(
                     operation,
                     "server_after_ffi",
                     None,
                     Some(&format!(
-                        "id={} status={status} response_kind={} payload_bytes={}",
+                        "id={} status={status} response_kind={} payload_bytes={payload_bytes}",
                         request.id,
                         response_operation(&response_body).as_str(),
-                        payload.len()
                     )),
                 );
-                match server_response_with_payload(request.id, status, response_body, payload) {
+                match server_response_with_call_payload(request.id, status, response_body, payload)
+                {
                     Ok(response) => response,
                     Err(error) => {
                         write_worker_trace(
@@ -202,6 +257,26 @@ impl ServerResponse {
             response: self,
             payload,
         }
+    }
+}
+
+fn server_response_with_call_payload(
+    id: u64,
+    status: i32,
+    response: AssetStudioFfiResponse,
+    payload: CallPayload,
+) -> io::Result<ServerResponseWithPayload> {
+    match payload {
+        CallPayload::Inline(payload) => server_response_with_payload(id, status, response, payload),
+        CallPayload::File { path, len } => Ok(ServerResponse {
+            id,
+            status: Some(status),
+            response: Some(response),
+            payload_len: len as usize,
+            payload_file: Some(path.to_string_lossy().to_string()),
+            error: None,
+        }
+        .with_payload(Vec::new())),
     }
 }
 
@@ -289,8 +364,8 @@ fn spill_payload_to_temp_file(payload: &[u8]) -> io::Result<PathBuf> {
 fn spill_payload_into_dir(payload: &[u8], dir: Option<&Path>) -> io::Result<PathBuf> {
     let mut builder = tempfile::Builder::new();
     builder
-        .prefix("haruki-assetstudio-worker-payload-")
-        .suffix(".bin");
+        .prefix(WORKER_PAYLOAD_FILE_PREFIX)
+        .suffix(WORKER_PAYLOAD_FILE_SUFFIX);
     let mut file = match dir {
         Some(dir) => builder.tempfile_in(dir)?,
         None => builder.tempfile()?,
@@ -304,16 +379,24 @@ fn spill_payload_into_dir(payload: &[u8], dir: Option<&Path>) -> io::Result<Path
 fn call_native_with_stdout_suppressed(
     native_library: &LoadedAssetStudioFfiLibrary,
     request: &AssetStudioFfiRequest,
-) -> Result<(i32, AssetStudioFfiResponse, Vec<u8>), Box<AssetStudioFfiError>> {
+) -> Result<(i32, AssetStudioFfiResponse, CallPayload), Box<AssetStudioFfiError>> {
+    let spill = PayloadSpillPlan {
+        directory: payload_spill_dir(),
+        threshold: payload_file_threshold(),
+    };
     #[cfg(unix)]
     {
         let _guard = StdoutRedirectGuard::to_null();
-        native_library.call_typed_request(request).map_err(Box::new)
+        native_library
+            .call_typed_request_with_spill(request, Some(&spill))
+            .map_err(Box::new)
     }
 
     #[cfg(not(unix))]
     {
-        native_library.call_typed_request(request).map_err(Box::new)
+        native_library
+            .call_typed_request_with_spill(request, Some(&spill))
+            .map_err(Box::new)
     }
 }
 
@@ -514,8 +597,8 @@ mod tests {
     use std::io::{self, Cursor};
 
     use super::{
-        read_frame, spill_payload_into_dir, spill_payload_to_temp_file, write_frame,
-        MAX_FRAME_SIZE,
+        read_frame, spill_payload_into_dir, spill_payload_to_temp_file,
+        sweep_stale_spill_files_in, write_frame, MAX_FRAME_SIZE,
     };
 
     #[test]
@@ -567,5 +650,28 @@ mod tests {
         assert_eq!(payload_file.parent(), Some(dir.path()));
         assert_eq!(std::fs::read(&payload_file).unwrap(), payload);
         std::fs::remove_file(&payload_file).unwrap();
+    }
+
+    #[test]
+    fn server_stale_spill_sweep_removes_only_old_spill_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let stale = spill_payload_into_dir(b"stale", Some(dir.path())).unwrap();
+        let unrelated = dir.path().join("unrelated.bin");
+        std::fs::write(&unrelated, b"keep").unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        // Everything older than 10ms is stale; only the worker-prefixed file goes.
+        let removed = sweep_stale_spill_files_in(dir.path(), std::time::Duration::from_millis(10));
+
+        assert_eq!(removed, 1);
+        assert!(!stale.exists());
+        assert!(unrelated.exists());
+
+        // A fresh spill file survives a sweep with the real five-minute horizon.
+        let fresh = spill_payload_into_dir(b"fresh", Some(dir.path())).unwrap();
+        let removed =
+            sweep_stale_spill_files_in(dir.path(), super::STALE_SPILL_FILE_MAX_AGE);
+        assert_eq!(removed, 0);
+        assert!(fresh.exists());
     }
 }

--- a/crates/assetstudio-ffi/src/bin/assetstudio_ffi_worker.rs
+++ b/crates/assetstudio-ffi/src/bin/assetstudio_ffi_worker.rs
@@ -470,7 +470,6 @@ fn response_operation(response: &AssetStudioFfiResponse) -> AssetStudioFfiOperat
             AssetStudioFfiOperation::ContextListObjects
         }
         AssetStudioFfiResponse::ContextClose(_) => AssetStudioFfiOperation::ContextClose,
-        AssetStudioFfiResponse::ContextReadObject(_) => AssetStudioFfiOperation::ContextReadObject,
         AssetStudioFfiResponse::ContextReadObjects(_) => {
             AssetStudioFfiOperation::ContextReadObjects
         }

--- a/crates/assetstudio-ffi/src/frame.rs
+++ b/crates/assetstudio-ffi/src/frame.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
-pub async fn write_worker_frame<W>(writer: &mut W, payload: &[u8]) -> io::Result<()>
+pub(crate) async fn write_worker_frame<W>(writer: &mut W, payload: &[u8]) -> io::Result<()>
 where
     W: AsyncWrite + Unpin,
 {
@@ -13,7 +13,7 @@ where
     writer.flush().await
 }
 
-pub async fn read_worker_frame<R>(reader: &mut R) -> io::Result<Vec<u8>>
+pub(crate) async fn read_worker_frame<R>(reader: &mut R) -> io::Result<Vec<u8>>
 where
     R: AsyncRead + Unpin,
 {

--- a/crates/assetstudio-ffi/src/lib.rs
+++ b/crates/assetstudio-ffi/src/lib.rs
@@ -4,7 +4,10 @@ mod types;
 mod worker_pool;
 
 pub use frame::{read_worker_frame, write_worker_frame};
-pub use native::{call_assetstudio_ffi_typed_request, LoadedAssetStudioFfiLibrary};
+pub use native::{
+    call_assetstudio_ffi_typed_request, CallPayload, LoadedAssetStudioFfiLibrary, PayloadSpillPlan,
+    WORKER_PAYLOAD_FILE_PREFIX, WORKER_PAYLOAD_FILE_SUFFIX,
+};
 pub use types::{
     AssetStudioFfiAssetInfo, AssetStudioFfiContextCloseRequest, AssetStudioFfiContextCloseResponse,
     AssetStudioFfiContextListObjectsRequest, AssetStudioFfiContextListObjectsResponse,

--- a/crates/assetstudio-ffi/src/lib.rs
+++ b/crates/assetstudio-ffi/src/lib.rs
@@ -3,23 +3,20 @@ mod native;
 mod types;
 mod worker_pool;
 
-pub use frame::{read_worker_frame, write_worker_frame};
 pub use native::{
-    call_assetstudio_ffi_typed_request, CallPayload, LoadedAssetStudioFfiLibrary, PayloadSpillPlan,
-    WORKER_PAYLOAD_FILE_PREFIX, WORKER_PAYLOAD_FILE_SUFFIX,
+    CallPayload, LoadedAssetStudioFfiLibrary, PayloadSpillPlan, WORKER_PAYLOAD_FILE_PREFIX,
+    WORKER_PAYLOAD_FILE_SUFFIX,
 };
 pub use types::{
     AssetStudioFfiAssetInfo, AssetStudioFfiContextCloseRequest, AssetStudioFfiContextCloseResponse,
     AssetStudioFfiContextListObjectsRequest, AssetStudioFfiContextListObjectsResponse,
     AssetStudioFfiContextOpenRequest, AssetStudioFfiContextOpenResponse,
-    AssetStudioFfiContextReadObjectItemRequest, AssetStudioFfiContextReadObjectRequest,
-    AssetStudioFfiContextReadObjectsRequest, AssetStudioFfiError,
-    AssetStudioFfiObjectReadBatchResponse, AssetStudioFfiObjectReadOutput,
+    AssetStudioFfiContextReadObjectItemRequest, AssetStudioFfiContextReadObjectsRequest,
+    AssetStudioFfiError, AssetStudioFfiObjectReadBatchResponse, AssetStudioFfiObjectReadOutput,
     AssetStudioFfiObjectReadResponse, AssetStudioFfiOperation, AssetStudioFfiRequest,
-    AssetStudioFfiResponse, NativeBatchPhaseStats,
+    AssetStudioFfiResponse,
 };
 pub use worker_pool::{
-    configured_worker_path, with_worker_lease, worker_executable_name, AssetStudioWorkerPool,
-    WorkerLease, WorkerLeaseStats, WorkerOutput, WorkerPoolStatsSnapshot, WorkerServerRequest,
-    WorkerServerResponse,
+    configured_worker_path, worker_executable_name, AssetStudioWorkerPool, WorkerLease,
+    WorkerLeaseStats, WorkerOutput, WorkerPoolStatsSnapshot,
 };

--- a/crates/assetstudio-ffi/src/native.rs
+++ b/crates/assetstudio-ffi/src/native.rs
@@ -4,7 +4,6 @@ use std::mem::size_of;
 use std::os::raw::{c_char, c_int, c_longlong, c_uchar};
 use std::path::{Path, PathBuf};
 use std::ptr;
-use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use tracing::warn;
 
@@ -390,20 +389,6 @@ impl Drop for EnvVarGuard {
             None => std::env::remove_var(self.name),
         }
     }
-}
-
-fn native_call_lock() -> MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
-}
-
-pub fn call_assetstudio_ffi_typed_request(
-    native_library_path: &str,
-    request: &AssetStudioFfiRequest,
-) -> Result<(c_int, AssetStudioFfiResponse, Vec<u8>), AssetStudioFfiError> {
-    let _lock = native_call_lock();
-    let library = LoadedAssetStudioFfiLibrary::load(native_library_path)?;
-    library.call_typed_request(request)
 }
 
 pub struct LoadedAssetStudioFfiLibrary {
@@ -807,37 +792,6 @@ impl LoadedAssetStudioFfiLibrary {
                     status,
                     AssetStudioFfiResponse::ContextClose(response),
                     Vec::new(),
-                ))
-            }
-            AssetStudioFfiRequest::ContextReadObject(request) => {
-                let batch_request = AssetStudioFfiContextReadObjectsRequest {
-                    context_id: request.context_id,
-                    objects: vec![AssetStudioFfiContextReadObjectItemRequest {
-                        path_id: request.path_id,
-                        kind: request.kind.clone(),
-                        image_format: request.image_format.clone(),
-                    }],
-                    payload_capacity_hint: 0,
-                };
-                let (status, batch_response, payload) =
-                    self.read_context_objects(&batch_request)?;
-                let response = batch_response.reads.into_iter().next().unwrap_or_else(|| {
-                    AssetStudioFfiObjectReadResponse {
-                        success: false,
-                        asset: None,
-                        payload_kind: None,
-                        payload_len: 0,
-                        suggested_extension: None,
-                        warnings: Vec::new(),
-                        phase_ms: HashMap::new(),
-                        error: Some("typed context_read_object returned no read item".to_string()),
-                        duration_ms: None,
-                    }
-                });
-                Ok((
-                    status,
-                    AssetStudioFfiResponse::ContextReadObject(response),
-                    payload,
                 ))
             }
             AssetStudioFfiRequest::ContextReadObjects(request) => {
@@ -1679,7 +1633,6 @@ fn typed_read_objects_response(
         reads,
         warnings: Vec::new(),
         phase_ms,
-        asset_type_counts: HashMap::new(),
         payload_kind_counts,
         payload_bytes_by_kind,
         payload_len: response.payload_len,
@@ -1697,9 +1650,6 @@ fn typed_read_objects_response(
         } else {
             0
         },
-        worker_id: None,
-        call_seq: None,
-        phase_stats: HashMap::new(),
         error: (!success).then(|| {
             format!(
                 "typed context_read_objects_direct_retry_v1 failed: requested={} status={} response_status={} error_code={}",

--- a/crates/assetstudio-ffi/src/native.rs
+++ b/crates/assetstudio-ffi/src/native.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::ffi::CString;
 use std::mem::size_of;
 use std::os::raw::{c_char, c_int, c_longlong, c_uchar};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::ptr;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
@@ -745,6 +745,38 @@ impl LoadedAssetStudioFfiLibrary {
         Ok(response)
     }
 
+    /// Like [`call_typed_request`], but read payloads whose capacity hint exceeds
+    /// the plan's threshold are written by the native library straight into a spill
+    /// file (returned as [`CallPayload::File`]) instead of an in-memory bundle.
+    pub fn call_typed_request_with_spill(
+        &self,
+        request: &AssetStudioFfiRequest,
+        spill: Option<&PayloadSpillPlan>,
+    ) -> Result<(c_int, AssetStudioFfiResponse, CallPayload), AssetStudioFfiError> {
+        #[cfg(unix)]
+        if let (AssetStudioFfiRequest::ContextReadObjects(read_request), Some(plan)) =
+            (request, spill)
+        {
+            let hint = usize::try_from(read_request.payload_capacity_hint).unwrap_or(usize::MAX);
+            if hint > plan.threshold && !read_request.objects.is_empty() {
+                if let Some((status, response, payload)) = self
+                    .read_context_objects_into_spill_file(read_request, plan.directory.as_deref())?
+                {
+                    return Ok((
+                        status,
+                        AssetStudioFfiResponse::ContextReadObjects(response),
+                        payload,
+                    ));
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        let _ = spill;
+
+        let (status, response, payload) = self.call_typed_request(request)?;
+        Ok((status, response, CallPayload::Inline(payload)))
+    }
+
     pub fn call_typed_request(
         &self,
         request: &AssetStudioFfiRequest,
@@ -785,6 +817,7 @@ impl LoadedAssetStudioFfiLibrary {
                         kind: request.kind.clone(),
                         image_format: request.image_format.clone(),
                     }],
+                    payload_capacity_hint: 0,
                 };
                 let (status, batch_response, payload) =
                     self.read_context_objects(&batch_request)?;
@@ -966,42 +999,8 @@ impl LoadedAssetStudioFfiLibrary {
         &self,
         request: &AssetStudioFfiContextReadObjectsRequest,
     ) -> Result<(c_int, AssetStudioFfiObjectReadBatchResponse, Vec<u8>), AssetStudioFfiError> {
-        let mut kinds = Vec::with_capacity(request.objects.len());
-        let mut formats = Vec::with_capacity(request.objects.len());
-        let mut items = Vec::with_capacity(request.objects.len());
-        for item in &request.objects {
-            let kind = CString::new(item.kind.clone()).map_err(|source| {
-                AssetStudioFfiError::AssetStudioFfi {
-                    message: format!("native read kind contains nul byte: {source}"),
-                }
-            })?;
-            let format = CString::new(item.image_format.clone()).map_err(|source| {
-                AssetStudioFfiError::AssetStudioFfi {
-                    message: format!("native read image format contains nul byte: {source}"),
-                }
-            })?;
-            items.push(AssetStudioTypedObjectReadItemRequest {
-                path_id: item.path_id,
-                kind_utf8: kind.as_ptr().cast(),
-                kind_utf8_len: kind.as_bytes().len() as c_int,
-                image_format_utf8: format.as_ptr().cast(),
-                image_format_utf8_len: format.as_bytes().len() as c_int,
-            });
-            kinds.push(kind);
-            formats.push(format);
-        }
-        let typed_request = AssetStudioTypedObjectReadBatchIntoRequest {
-            struct_size: size_of::<AssetStudioTypedObjectReadBatchIntoRequest>() as c_int,
-            context_id: request.context_id,
-            items: items.as_ptr(),
-            count: items.len() as c_int,
-            flags: 0,
-            items_buffer: ptr::null_mut(),
-            items_buffer_len: 0,
-            payload: ptr::null_mut(),
-            payload_len: 0,
-            reserved: 0,
-        };
+        let storage = build_typed_read_items(request)?;
+        let typed_request = typed_read_batch_request(request.context_id, &storage, ptr::null_mut(), 0);
         let mut response = AssetStudioTypedObjectReadBatchRetryResponse::default();
         let status =
             unsafe { (self.context_read_objects_direct_retry)(&typed_request, &mut response) };
@@ -1019,6 +1018,422 @@ impl LoadedAssetStudioFfiLibrary {
             status.max(response.status)
         };
         Ok((call_status, output, payload))
+    }
+
+    /// Direct-write read: the payload block is written by the native library
+    /// straight into a mapped spill file laid out as a grouped V1 bundle. Returns
+    /// `Ok(None)` when the file/mapping could not be prepared, in which case the
+    /// caller should fall back to the in-memory path.
+    #[cfg(unix)]
+    fn read_context_objects_into_spill_file(
+        &self,
+        request: &AssetStudioFfiContextReadObjectsRequest,
+        directory: Option<&Path>,
+    ) -> Result<Option<(c_int, AssetStudioFfiObjectReadBatchResponse, CallPayload)>, AssetStudioFfiError>
+    {
+        let names = request
+            .objects
+            .iter()
+            .map(|item| item.path_id.to_string())
+            .collect::<Vec<_>>();
+        let header_len = grouped_bundle_header_len(&names);
+        let Ok(hint) = usize::try_from(request.payload_capacity_hint) else {
+            return Ok(None);
+        };
+        let Some(capacity) = header_len.checked_add(hint) else {
+            return Ok(None);
+        };
+
+        let mut builder = tempfile::Builder::new();
+        builder
+            .prefix(WORKER_PAYLOAD_FILE_PREFIX)
+            .suffix(WORKER_PAYLOAD_FILE_SUFFIX);
+        let temp = match directory {
+            Some(directory) => builder.tempfile_in(directory),
+            None => builder.tempfile(),
+        };
+        // Preparation failures (missing dir, tmpfs full, mmap refusal) are not call
+        // failures: report None so the caller retries through the in-memory path.
+        let Ok(temp) = temp else {
+            return Ok(None);
+        };
+        let (file, path) = match temp.keep() {
+            Ok(kept) => kept,
+            Err(_) => return Ok(None),
+        };
+        // Reserve backing blocks before exposing the mapping to the decoder. A bare
+        // set_len leaves the file sparse, and on tmpfs a write into an unbacked page
+        // raises SIGBUS when space runs out — killing the process instead of failing
+        // the call. With the reservation, exhaustion surfaces here as ENOSPC and the
+        // caller retries through the in-memory path. The over-reservation is
+        // transient: the final set_len below releases everything past the real size.
+        if reserve_file_capacity(&file, capacity as u64).is_err() {
+            let _ = std::fs::remove_file(&path);
+            return Ok(None);
+        }
+        if file.set_len(capacity as u64).is_err() {
+            let _ = std::fs::remove_file(&path);
+            return Ok(None);
+        }
+        let mut mapping = match RwFileMapping::map(&file, capacity) {
+            Ok(mapping) => mapping,
+            Err(_) => {
+                let _ = std::fs::remove_file(&path);
+                return Ok(None);
+            }
+        };
+        let length_positions = write_grouped_bundle_header(mapping.as_mut_slice(), &names);
+
+        let cleanup = |mapping: RwFileMapping, path: &Path| {
+            drop(mapping);
+            let _ = std::fs::remove_file(path);
+        };
+
+        let storage = match build_typed_read_items(request) {
+            Ok(storage) => storage,
+            Err(error) => {
+                cleanup(mapping, &path);
+                return Err(error);
+            }
+        };
+        let payload_pointer = unsafe { (mapping.pointer as *mut c_uchar).add(header_len) };
+        let typed_request = typed_read_batch_request(
+            request.context_id,
+            &storage,
+            payload_pointer,
+            (capacity - header_len) as c_longlong,
+        );
+        let mut response = AssetStudioTypedObjectReadBatchRetryResponse::default();
+        let status =
+            unsafe { (self.context_read_objects_direct_retry)(&typed_request, &mut response) };
+        let output = typed_read_objects_response(request, status, &response);
+        let items = typed_read_items(&response);
+
+        if items.len() != request.objects.len() {
+            // Unexpected response shape: keep the proven in-memory bundle path while
+            // the native buffers are still alive.
+            let payload = typed_read_objects_payload_bundle(&response);
+            if response.result_handle != 0 {
+                unsafe {
+                    (self.result_free)(response.result_handle);
+                }
+            }
+            cleanup(mapping, &path);
+            let payload = payload?;
+            let call_status = if output.success {
+                0
+            } else {
+                status.max(response.status)
+            };
+            return Ok(Some((call_status, output, CallPayload::Inline(payload))));
+        }
+
+        let mut data_len = 0u64;
+        for (item, position) in items.iter().zip(&length_positions) {
+            let len = item.payload_len.max(0) as u64;
+            data_len = data_len.saturating_add(len);
+            patch_grouped_bundle_length(mapping.as_mut_slice(), *position, len);
+        }
+        let response_payload_len = response.payload_len.max(0) as u64;
+        let final_data_len = data_len.max(response_payload_len);
+
+        let payload_spilled = response.ownership_flags & TYPED_PAYLOAD_OWNERSHIP_FLAG != 0;
+        let mut copy_result = Ok(());
+        if payload_spilled && !response.payload.is_null() && response_payload_len > 0 {
+            // The capacity hint was too small: the native library kept the block in
+            // its own buffer. Grow the file and copy the block over (the only copy on
+            // this path, and only on hint misses).
+            copy_result = (|| -> std::io::Result<()> {
+                let required = header_len as u64 + response_payload_len;
+                if required > capacity as u64 {
+                    let remapped_len = usize::try_from(required).map_err(|_| {
+                        std::io::Error::new(std::io::ErrorKind::OutOfMemory, "payload too large")
+                    })?;
+                    let previous = std::mem::replace(&mut mapping, RwFileMapping {
+                        pointer: libc::MAP_FAILED,
+                        len: 0,
+                    });
+                    drop(previous);
+                    reserve_file_capacity(&file, required)?;
+                    file.set_len(required)?;
+                    mapping = RwFileMapping::map(&file, remapped_len)?;
+                }
+                let source = unsafe {
+                    std::slice::from_raw_parts(response.payload, response_payload_len as usize)
+                };
+                mapping.as_mut_slice()[header_len..header_len + source.len()]
+                    .copy_from_slice(source);
+                Ok(())
+            })();
+        }
+        // If the file cannot hold the grown payload (e.g. tmpfs lacks room), salvage
+        // the call through the in-memory bundle while the native buffers are still
+        // alive instead of failing the whole batch.
+        let inline_fallback = if copy_result.is_err() {
+            Some(typed_read_objects_payload_bundle(&response))
+        } else {
+            None
+        };
+        if response.result_handle != 0 {
+            unsafe {
+                (self.result_free)(response.result_handle);
+            }
+        }
+        if let Some(payload) = inline_fallback {
+            cleanup(mapping, &path);
+            let payload = payload?;
+            let call_status = if output.success {
+                0
+            } else {
+                status.max(response.status)
+            };
+            return Ok(Some((call_status, output, CallPayload::Inline(payload))));
+        }
+
+        drop(mapping);
+        let final_len = header_len as u64 + final_data_len;
+        if file.set_len(final_len).is_err() {
+            let _ = std::fs::remove_file(&path);
+            return Err(AssetStudioFfiError::AssetStudioFfi {
+                message: "failed to finalize payload spill file length".to_string(),
+            });
+        }
+
+        let call_status = if output.success {
+            0
+        } else {
+            status.max(response.status)
+        };
+        Ok(Some((
+            call_status,
+            output,
+            CallPayload::File {
+                path,
+                len: final_len,
+            },
+        )))
+    }
+}
+
+struct TypedReadItemStorage {
+    _kinds: Vec<CString>,
+    _formats: Vec<CString>,
+    items: Vec<AssetStudioTypedObjectReadItemRequest>,
+}
+
+fn build_typed_read_items(
+    request: &AssetStudioFfiContextReadObjectsRequest,
+) -> Result<TypedReadItemStorage, AssetStudioFfiError> {
+    let mut kinds = Vec::with_capacity(request.objects.len());
+    let mut formats = Vec::with_capacity(request.objects.len());
+    let mut items = Vec::with_capacity(request.objects.len());
+    for item in &request.objects {
+        let kind =
+            CString::new(item.kind.clone()).map_err(|source| AssetStudioFfiError::AssetStudioFfi {
+                message: format!("native read kind contains nul byte: {source}"),
+            })?;
+        let format = CString::new(item.image_format.clone()).map_err(|source| {
+            AssetStudioFfiError::AssetStudioFfi {
+                message: format!("native read image format contains nul byte: {source}"),
+            }
+        })?;
+        items.push(AssetStudioTypedObjectReadItemRequest {
+            path_id: item.path_id,
+            kind_utf8: kind.as_ptr().cast(),
+            kind_utf8_len: kind.as_bytes().len() as c_int,
+            image_format_utf8: format.as_ptr().cast(),
+            image_format_utf8_len: format.as_bytes().len() as c_int,
+        });
+        kinds.push(kind);
+        formats.push(format);
+    }
+    Ok(TypedReadItemStorage {
+        _kinds: kinds,
+        _formats: formats,
+        items,
+    })
+}
+
+fn typed_read_batch_request(
+    context_id: i64,
+    storage: &TypedReadItemStorage,
+    payload: *mut c_uchar,
+    payload_len: c_longlong,
+) -> AssetStudioTypedObjectReadBatchIntoRequest {
+    AssetStudioTypedObjectReadBatchIntoRequest {
+        struct_size: size_of::<AssetStudioTypedObjectReadBatchIntoRequest>() as c_int,
+        context_id,
+        items: storage.items.as_ptr(),
+        count: storage.items.len() as c_int,
+        flags: 0,
+        items_buffer: ptr::null_mut(),
+        items_buffer_len: 0,
+        payload,
+        payload_len,
+        reserved: 0,
+    }
+}
+
+#[cfg(unix)]
+const NATIVE_AOT_PAYLOAD_BUNDLE_V1_MAGIC: &[u8] = b"HARUKI_ASSET_PAYLOAD_BUNDLE_V1";
+#[cfg(unix)]
+const TYPED_PAYLOAD_OWNERSHIP_FLAG: c_int = 2;
+
+/// Name prefix/suffix shared by every worker-created payload spill file, so a
+/// restarted worker can recognize and sweep stale ones left by a crash.
+pub const WORKER_PAYLOAD_FILE_PREFIX: &str = "haruki-assetstudio-worker-payload-";
+pub const WORKER_PAYLOAD_FILE_SUFFIX: &str = ".bin";
+
+/// Where and when the worker may spill read payloads to a file the parent maps.
+pub struct PayloadSpillPlan {
+    /// Preferred spill directory (tmpfs); `None` uses the system temp directory.
+    pub directory: Option<PathBuf>,
+    /// Direct-write applies only when the request's payload capacity hint exceeds this.
+    pub threshold: usize,
+}
+
+/// A typed call's payload: inline bytes for small results, or a spill file the
+/// native library wrote its payload block into (grouped V1 bundle layout).
+pub enum CallPayload {
+    Inline(Vec<u8>),
+    File { path: PathBuf, len: u64 },
+}
+
+#[cfg(unix)]
+fn grouped_bundle_header_len(names: &[String]) -> usize {
+    NATIVE_AOT_PAYLOAD_BUNDLE_V1_MAGIC.len()
+        + 4
+        + names.iter().map(|name| 4 + 8 + name.len()).sum::<usize>()
+}
+
+/// Writes a grouped V1 bundle header with zeroed payload lengths and returns the
+/// byte position of each length field so they can be patched after the read.
+#[cfg(unix)]
+fn write_grouped_bundle_header(buffer: &mut [u8], names: &[String]) -> Vec<usize> {
+    let magic = NATIVE_AOT_PAYLOAD_BUNDLE_V1_MAGIC;
+    let mut cursor = 0usize;
+    buffer[cursor..cursor + magic.len()].copy_from_slice(magic);
+    cursor += magic.len();
+    buffer[cursor..cursor + 4].copy_from_slice(&(names.len() as u32).to_le_bytes());
+    cursor += 4;
+    let mut length_positions = Vec::with_capacity(names.len());
+    for name in names {
+        buffer[cursor..cursor + 4].copy_from_slice(&(name.len() as u32).to_le_bytes());
+        cursor += 4;
+        length_positions.push(cursor);
+        buffer[cursor..cursor + 8].copy_from_slice(&0u64.to_le_bytes());
+        cursor += 8;
+        buffer[cursor..cursor + name.len()].copy_from_slice(name.as_bytes());
+        cursor += name.len();
+    }
+    debug_assert_eq!(cursor, grouped_bundle_header_len(names));
+    length_positions
+}
+
+#[cfg(unix)]
+fn patch_grouped_bundle_length(buffer: &mut [u8], position: usize, len: u64) {
+    buffer[position..position + 8].copy_from_slice(&len.to_le_bytes());
+}
+
+/// Reserves backing blocks for the first `len` bytes of `file`, so that later
+/// writes through a shared mapping cannot hit an unbacked page. Without the
+/// reservation, filesystem exhaustion (tmpfs in particular) surfaces as SIGBUS
+/// at write time; with it, exhaustion surfaces here as ENOSPC.
+#[cfg(target_os = "linux")]
+fn reserve_file_capacity(file: &std::fs::File, len: u64) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    if len == 0 {
+        return Ok(());
+    }
+    let len = i64::try_from(len).map_err(|_| {
+        std::io::Error::new(std::io::ErrorKind::OutOfMemory, "spill capacity exceeds i64")
+    })?;
+    loop {
+        // posix_fallocate returns the error number directly instead of via errno.
+        match unsafe { libc::posix_fallocate(file.as_raw_fd(), 0, len) } {
+            0 => return Ok(()),
+            libc::EINTR => continue,
+            error => return Err(std::io::Error::from_raw_os_error(error)),
+        }
+    }
+}
+
+/// See the Linux variant. macOS has no posix_fallocate; F_PREALLOCATE extends
+/// the allocation from the current end of file and leaves the size unchanged.
+#[cfg(target_os = "macos")]
+fn reserve_file_capacity(file: &std::fs::File, len: u64) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let current = file.metadata()?.len();
+    if len <= current {
+        return Ok(());
+    }
+    let delta = i64::try_from(len - current).map_err(|_| {
+        std::io::Error::new(std::io::ErrorKind::OutOfMemory, "spill capacity exceeds i64")
+    })?;
+    let mut store = libc::fstore_t {
+        fst_flags: libc::F_ALLOCATEALL,
+        fst_posmode: libc::F_PEOFPOSMODE,
+        fst_offset: 0,
+        fst_length: delta,
+        fst_bytesalloc: 0,
+    };
+    if unsafe { libc::fcntl(file.as_raw_fd(), libc::F_PREALLOCATE, &mut store) } == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// No portable reservation on the remaining unix targets; keep the previous
+/// sparse-file behavior there.
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+fn reserve_file_capacity(_file: &std::fs::File, _len: u64) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// A read/write shared mapping of a spill file. Writes are visible to any other
+/// process that maps or reads the same file through the unified page cache.
+#[cfg(unix)]
+struct RwFileMapping {
+    pointer: *mut libc::c_void,
+    len: usize,
+}
+
+#[cfg(unix)]
+impl RwFileMapping {
+    fn map(file: &std::fs::File, len: usize) -> std::io::Result<Self> {
+        use std::os::fd::AsRawFd;
+
+        let pointer = unsafe {
+            libc::mmap(
+                ptr::null_mut(),
+                len,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                file.as_raw_fd(),
+                0,
+            )
+        };
+        if pointer == libc::MAP_FAILED {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(Self { pointer, len })
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.pointer as *mut u8, self.len) }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for RwFileMapping {
+    fn drop(&mut self) {
+        if self.pointer != libc::MAP_FAILED && self.len > 0 {
+            unsafe {
+                libc::munmap(self.pointer, self.len);
+            }
+        }
     }
 }
 
@@ -1414,4 +1829,60 @@ unsafe fn load_assetstudio_ffi_dependency(
     dependency_path: &Path,
 ) -> Result<libloading::Library, libloading::Error> {
     libloading::Library::new(dependency_path)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grouped_bundle_header_round_trips_through_patching() {
+        let names = vec!["7".to_string(), "12345".to_string(), "-9".to_string()];
+        let header_len = grouped_bundle_header_len(&names);
+        let mut buffer = vec![0u8; header_len + 6];
+        let positions = write_grouped_bundle_header(&mut buffer, &names);
+        assert_eq!(positions.len(), names.len());
+
+        patch_grouped_bundle_length(&mut buffer, positions[0], 3);
+        patch_grouped_bundle_length(&mut buffer, positions[1], 0);
+        patch_grouped_bundle_length(&mut buffer, positions[2], 3);
+        buffer[header_len..header_len + 3].copy_from_slice(b"abc");
+        buffer[header_len + 3..header_len + 6].copy_from_slice(b"xyz");
+
+        // Parse back with the grouped V1 layout rules used by the parent process.
+        let magic = NATIVE_AOT_PAYLOAD_BUNDLE_V1_MAGIC;
+        assert!(buffer.starts_with(magic));
+        let mut cursor = magic.len();
+        let count = u32::from_le_bytes(buffer[cursor..cursor + 4].try_into().unwrap());
+        cursor += 4;
+        assert_eq!(count, 3);
+        let mut entries = Vec::new();
+        for _ in 0..count {
+            let name_len =
+                u32::from_le_bytes(buffer[cursor..cursor + 4].try_into().unwrap()) as usize;
+            cursor += 4;
+            let payload_len =
+                u64::from_le_bytes(buffer[cursor..cursor + 8].try_into().unwrap()) as usize;
+            cursor += 8;
+            let name = String::from_utf8(buffer[cursor..cursor + name_len].to_vec()).unwrap();
+            cursor += name_len;
+            entries.push((name, payload_len));
+        }
+        assert_eq!(cursor, header_len);
+        assert_eq!(
+            entries,
+            vec![
+                ("7".to_string(), 3),
+                ("12345".to_string(), 0),
+                ("-9".to_string(), 3),
+            ]
+        );
+        let mut data_cursor = header_len;
+        let mut payloads = Vec::new();
+        for (_, len) in &entries {
+            payloads.push(buffer[data_cursor..data_cursor + len].to_vec());
+            data_cursor += len;
+        }
+        assert_eq!(payloads, vec![b"abc".to_vec(), Vec::new(), b"xyz".to_vec()]);
+    }
 }

--- a/crates/assetstudio-ffi/src/types.rs
+++ b/crates/assetstudio-ffi/src/types.rs
@@ -207,7 +207,8 @@ pub struct NativeBatchPhaseStats {
 #[derive(Debug, Clone)]
 pub struct AssetStudioFfiObjectReadOutput {
     pub response: AssetStudioFfiObjectReadResponse,
-    pub payload: Vec<u8>,
+    /// Shared slice of the read-batch payload bundle; cloning is a refcount bump.
+    pub payload: bytes::Bytes,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/assetstudio-ffi/src/types.rs
+++ b/crates/assetstudio-ffi/src/types.rs
@@ -121,14 +121,6 @@ pub struct AssetStudioFfiContextListObjectsResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AssetStudioFfiContextReadObjectRequest {
-    pub context_id: i64,
-    pub path_id: i64,
-    pub kind: String,
-    pub image_format: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssetStudioFfiContextReadObjectsRequest {
     pub context_id: i64,
     pub objects: Vec<AssetStudioFfiContextReadObjectItemRequest>,
@@ -172,8 +164,6 @@ pub struct AssetStudioFfiObjectReadBatchResponse {
     #[serde(default)]
     pub phase_ms: HashMap<String, u64>,
     #[serde(default)]
-    pub asset_type_counts: HashMap<String, usize>,
-    #[serde(default)]
     pub payload_kind_counts: HashMap<String, usize>,
     #[serde(default)]
     pub payload_bytes_by_kind: HashMap<String, u64>,
@@ -192,22 +182,8 @@ pub struct AssetStudioFfiObjectReadBatchResponse {
     pub failed_count: usize,
     #[serde(default)]
     pub read_payload_ms: u64,
-    #[serde(default)]
-    pub worker_id: Option<String>,
-    #[serde(default)]
-    pub call_seq: Option<u64>,
-    #[serde(default)]
-    pub phase_stats: HashMap<String, NativeBatchPhaseStats>,
     pub error: Option<String>,
     pub duration_ms: Option<u64>,
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct NativeBatchPhaseStats {
-    #[serde(default)]
-    pub p50_ms: u64,
-    #[serde(default)]
-    pub p95_ms: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -231,7 +207,6 @@ pub enum AssetStudioFfiOperation {
     ContextOpen,
     ContextListObjects,
     ContextClose,
-    ContextReadObject,
     ContextReadObjects,
 }
 
@@ -241,7 +216,6 @@ impl AssetStudioFfiOperation {
             Self::ContextOpen => "context_open",
             Self::ContextListObjects => "context_list_objects",
             Self::ContextClose => "context_close",
-            Self::ContextReadObject => "context_read_object",
             Self::ContextReadObjects => "context_read_objects",
         }
     }
@@ -253,7 +227,6 @@ pub enum AssetStudioFfiRequest {
     ContextOpen(AssetStudioFfiContextOpenRequest),
     ContextListObjects(AssetStudioFfiContextListObjectsRequest),
     ContextClose(AssetStudioFfiContextCloseRequest),
-    ContextReadObject(AssetStudioFfiContextReadObjectRequest),
     ContextReadObjects(AssetStudioFfiContextReadObjectsRequest),
 }
 
@@ -263,7 +236,6 @@ impl AssetStudioFfiRequest {
             Self::ContextOpen(_) => AssetStudioFfiOperation::ContextOpen,
             Self::ContextListObjects(_) => AssetStudioFfiOperation::ContextListObjects,
             Self::ContextClose(_) => AssetStudioFfiOperation::ContextClose,
-            Self::ContextReadObject(_) => AssetStudioFfiOperation::ContextReadObject,
             Self::ContextReadObjects(_) => AssetStudioFfiOperation::ContextReadObjects,
         }
     }
@@ -275,7 +247,6 @@ pub enum AssetStudioFfiResponse {
     ContextOpen(AssetStudioFfiContextOpenResponse),
     ContextListObjects(AssetStudioFfiContextListObjectsResponse),
     ContextClose(AssetStudioFfiContextCloseResponse),
-    ContextReadObject(AssetStudioFfiObjectReadResponse),
     ContextReadObjects(AssetStudioFfiObjectReadBatchResponse),
 }
 
@@ -304,13 +275,6 @@ impl AssetStudioFfiResponse {
         match self {
             Self::ContextClose(response) => Ok(response),
             other => Err(unexpected_native_response("context_close", &other)),
-        }
-    }
-
-    pub fn into_object_read(self) -> Result<AssetStudioFfiObjectReadResponse, AssetStudioFfiError> {
-        match self {
-            Self::ContextReadObject(response) => Ok(response),
-            other => Err(unexpected_native_response("context_read_object", &other)),
         }
     }
 

--- a/crates/assetstudio-ffi/src/types.rs
+++ b/crates/assetstudio-ffi/src/types.rs
@@ -132,6 +132,12 @@ pub struct AssetStudioFfiContextReadObjectRequest {
 pub struct AssetStudioFfiContextReadObjectsRequest {
     pub context_id: i64,
     pub objects: Vec<AssetStudioFfiContextReadObjectItemRequest>,
+    /// Expected upper bound for the packed payload block in bytes. When it exceeds
+    /// the worker's spill threshold, the worker maps a spill file up front and the
+    /// native library writes payloads straight into the mapping. 0 (the default for
+    /// older callers) keeps the in-memory path.
+    #[serde(default)]
+    pub payload_capacity_hint: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/assetstudio-ffi/src/worker_pool.rs
+++ b/crates/assetstudio-ffi/src/worker_pool.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::future::Future;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -17,20 +16,20 @@ use crate::frame::{read_worker_frame, write_worker_frame};
 use crate::types::*;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct WorkerServerRequest {
-    pub id: u64,
-    pub request: AssetStudioFfiRequest,
+pub(crate) struct WorkerServerRequest {
+    pub(crate) id: u64,
+    pub(crate) request: AssetStudioFfiRequest,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct WorkerServerResponse {
-    pub id: u64,
-    pub status: Option<i32>,
-    pub response: Option<AssetStudioFfiResponse>,
+pub(crate) struct WorkerServerResponse {
+    pub(crate) id: u64,
+    pub(crate) status: Option<i32>,
+    pub(crate) response: Option<AssetStudioFfiResponse>,
     #[serde(default)]
-    pub payload_len: usize,
-    pub payload_file: Option<String>,
-    pub error: Option<String>,
+    pub(crate) payload_len: usize,
+    pub(crate) payload_file: Option<String>,
+    pub(crate) error: Option<String>,
 }
 
 #[derive(Debug)]
@@ -480,10 +479,3 @@ fn absolute_command_path(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
-pub async fn with_worker_lease<T, E, F, Fut>(lease: &mut WorkerLease, f: F) -> Result<T, E>
-where
-    F: FnOnce(&mut WorkerLease) -> Fut,
-    Fut: Future<Output = Result<T, E>>,
-{
-    f(lease).await
-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,10 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: haruki-sekai-asset-updater
+    # FFI workers stream decoded payloads through /dev/shm-backed mapped files;
+    # the Docker default (64MB) forces the graceful in-memory fallback and loses
+    # the zero-copy path. tmpfs is a cap, not an allocation — generous is free.
+    shm_size: 2gb
     ports:
       - "${HTTP_PORT:-8080}:8080"
     volumes:

--- a/haruki-asset-configs.example.yaml
+++ b/haruki-asset-configs.example.yaml
@@ -57,8 +57,7 @@ backends:
       TextAsset: text_bytes
       MonoBehaviour: typetree_json
       AudioClip: audio
-      Animator: pjsk_model_package
-      AnimationClip: pjsk_animation_clip_decoded
+      Animator: fbx # requires linux-x64/macOS (no FBX SDK for linux-arm64); model packages & motion clips flow through the haruki_3d raw-bundle pipeline
       all: typetree_json
 
 resources:

--- a/src/core/codec.rs
+++ b/src/core/codec.rs
@@ -7,7 +7,8 @@ use serde::Serialize;
 
 use crate::core::errors::CodecError;
 
-pub const CODEC_BACKEND: &str = "crates.io:cridecoder@0.3.3";
+// Version intentionally omitted; see Cargo.toml for the pinned cridecoder version.
+pub const CODEC_BACKEND: &str = "crates.io:cridecoder";
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CodecSummary {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1019,12 +1019,13 @@ fn warn_media_fallback_backend_options(media: &MediaBackendConfig) {
 fn validate_asset_studio_ffi_read_kind(field: &str, value: &str) -> Result<(), ConfigError> {
     match value.trim().to_lowercase().as_str() {
         "auto" | "raw" | "typetree_json" | "image" | "image_archive" | "audio" | "video"
-        | "font" | "shader" | "text" | "text_bytes" | "mesh" | "obj" | "animator" | "fbx"
-        | "pjsk_model_package" | "pjsk_animation_clip_decoded" => Ok(()),
+        | "font" | "shader" | "text" | "text_bytes" | "mesh" | "obj" | "animator" | "fbx" => {
+            Ok(())
+        }
         other => Err(ConfigError::InvalidValue {
             field: field.to_string(),
             value: other.to_string(),
-            expected: "auto, raw, typetree_json, image, image_archive, audio, video, font, shader, text, text_bytes, mesh, obj, animator, fbx, pjsk_model_package, or pjsk_animation_clip_decoded".to_string(),
+            expected: "auto, raw, typetree_json, image, image_archive, audio, video, font, shader, text, text_bytes, mesh, obj, animator, or fbx".to_string(),
         }),
     }
 }
@@ -2361,19 +2362,22 @@ asset_studio:
     }
 
     #[test]
-    fn accepts_pjsk_asset_studio_ffi_read_kinds() {
-        let mut config = AppConfig::default();
-        config
-            .backends
-            .asset_studio
-            .read_kinds
-            .insert("Animator".to_string(), "pjsk_model_package".to_string());
-        config.backends.asset_studio.read_kinds.insert(
-            "AnimationClip".to_string(),
-            "pjsk_animation_clip_decoded".to_string(),
-        );
-
-        config.validate().unwrap();
+    fn rejects_unimplemented_pjsk_read_kinds() {
+        // The FFI dylib never implemented these kinds; model packages and motion
+        // clips flow through the haruki_3d raw-bundle pipeline instead. Accepting
+        // them here would silently drop every Animator/AnimationClip export.
+        for (asset_type, kind) in [
+            ("Animator", "pjsk_model_package"),
+            ("AnimationClip", "pjsk_animation_clip_decoded"),
+        ] {
+            let mut config = AppConfig::default();
+            config
+                .backends
+                .asset_studio
+                .read_kinds
+                .insert(asset_type.to_string(), kind.to_string());
+            config.validate().unwrap_err();
+        }
     }
 
     #[test]
@@ -2489,14 +2493,12 @@ haruki_3d:
         let asset_studio = &config.backends.asset_studio;
         assert_eq!(
             asset_studio.read_kinds.get("Animator").map(String::as_str),
-            Some("pjsk_model_package")
+            Some("fbx")
         );
         assert_eq!(
-            asset_studio
-                .read_kinds
-                .get("AnimationClip")
-                .map(String::as_str),
-            Some("pjsk_animation_clip_decoded")
+            asset_studio.read_kinds.get("AnimationClip"),
+            None,
+            "motion clips are consumed by the haruki_3d raw-bundle pipeline, not FFI reads"
         );
 
         let jp = config.regions.get("jp").expect("jp region exists");

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1176,6 +1176,7 @@ pub struct BackendsConfig {
 #[serde(default)]
 pub struct AssetStudioBackendConfig {
     pub library_path: Option<String>,
+    #[serde(alias = "call_mode")]
     pub mode: AssetStudioFfiMode,
     pub worker_path: Option<String>,
     pub process_concurrency: usize,
@@ -1185,10 +1186,9 @@ pub struct AssetStudioBackendConfig {
     pub read_kinds: BTreeMap<String, String>,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AssetStudioFfiMode {
-    Direct,
     #[default]
     WorkerPool,
 }
@@ -1198,14 +1198,30 @@ impl FromStr for AssetStudioFfiMode {
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value.trim().to_ascii_lowercase().as_str() {
-            "direct" => Ok(Self::Direct),
             "worker_pool" | "worker-pool" | "worker" | "pool" => Ok(Self::WorkerPool),
+            "direct" => Err(ConfigError::InvalidValue {
+                field: "backends.asset_studio.mode".to_string(),
+                value: "direct".to_string(),
+                expected: "worker_pool (direct mode was removed; use worker_pool)".to_string(),
+            }),
             other => Err(ConfigError::InvalidValue {
                 field: "backends.asset_studio.mode".to_string(),
                 value: other.to_string(),
-                expected: "direct or worker_pool".to_string(),
+                expected: "worker_pool".to_string(),
             }),
         }
+    }
+}
+
+// Manual Deserialize so both the yaml `mode` key and the env override share the
+// FromStr aliases and its clear "direct mode was removed" error.
+impl<'de> Deserialize<'de> for AssetStudioFfiMode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        value.parse().map_err(serde::de::Error::custom)
     }
 }
 
@@ -2151,7 +2167,7 @@ image:
   jpeg_quality: 88
 asset_studio:
   library_path: /tmp/libHarukiAssetStudioFFI.so
-  mode: direct
+  mode: worker_pool
   worker_path: /tmp/assetstudio-ffi-worker
   process_concurrency: 6
   worker_max_calls: 128
@@ -2172,7 +2188,7 @@ asset_studio:
             asset_studio.library_path.as_deref(),
             Some("/tmp/libHarukiAssetStudioFFI.so")
         );
-        assert_eq!(asset_studio.mode, AssetStudioFfiMode::Direct);
+        assert_eq!(asset_studio.mode, AssetStudioFfiMode::WorkerPool);
         assert_eq!(
             asset_studio.worker_path.as_deref(),
             Some("/tmp/assetstudio-ffi-worker")
@@ -2188,6 +2204,35 @@ asset_studio:
         assert_eq!(
             asset_studio.read_kinds.get("all").map(String::as_str),
             Some("typetree_json")
+        );
+    }
+
+    #[test]
+    fn rejects_removed_direct_asset_studio_mode() {
+        let err = "direct"
+            .parse::<AssetStudioFfiMode>()
+            .expect_err("removed direct mode should fail");
+        assert!(matches!(
+            &err,
+            ConfigError::InvalidValue { field, value, expected }
+                if field == "backends.asset_studio.mode"
+                    && value == "direct"
+                    && expected.contains("direct mode was removed")
+        ));
+
+        let yaml = "asset_studio:\n  mode: direct\n";
+        let err = yaml_serde::from_str::<BackendsConfig>(yaml)
+            .expect_err("removed direct mode should fail in yaml");
+        assert!(err.to_string().contains("direct mode was removed"));
+    }
+
+    #[test]
+    fn accepts_call_mode_alias_for_asset_studio_mode() {
+        let yaml = "asset_studio:\n  call_mode: pool\n";
+        let backends: BackendsConfig = yaml_serde::from_str(yaml).unwrap();
+        assert_eq!(
+            backends.asset_studio.mode,
+            AssetStudioFfiMode::WorkerPool
         );
     }
 
@@ -2684,7 +2729,7 @@ regions:
             "HARUKI_ASSET_STUDIO_FFI_LIBRARY_PATH",
             "/tmp/override-native.so",
         );
-        std::env::set_var("HARUKI_ASSET_STUDIO_FFI_MODE", "direct");
+        std::env::set_var("HARUKI_ASSET_STUDIO_FFI_MODE", "pool");
         std::env::set_var(
             "HARUKI_ASSET_STUDIO_FFI_WORKER_PATH",
             "/tmp/override-native-worker",
@@ -2729,7 +2774,7 @@ backends:
         );
         assert_eq!(
             config.backends.asset_studio.mode,
-            AssetStudioFfiMode::Direct
+            AssetStudioFfiMode::WorkerPool
         );
         assert_eq!(
             config.backends.asset_studio.worker_path.as_deref(),

--- a/src/core/export_pipeline/implementation.rs
+++ b/src/core/export_pipeline/implementation.rs
@@ -22,8 +22,7 @@ use haruki_assetstudio_ffi::{
     AssetStudioFfiContextOpenRequest, AssetStudioFfiContextOpenResponse,
     AssetStudioFfiContextReadObjectItemRequest, AssetStudioFfiContextReadObjectsRequest,
     AssetStudioFfiError, AssetStudioFfiObjectReadBatchResponse, AssetStudioFfiObjectReadOutput,
-    AssetStudioFfiRequest, AssetStudioWorkerPool, LoadedAssetStudioFfiLibrary,
-    NativeBatchPhaseStats, WorkerLease, WorkerLeaseStats, WorkerOutput,
+    AssetStudioFfiRequest, AssetStudioWorkerPool, WorkerLease, WorkerLeaseStats, WorkerOutput,
 };
 #[cfg(test)]
 use haruki_assetstudio_ffi::{AssetStudioFfiObjectReadResponse, AssetStudioFfiResponse};
@@ -31,9 +30,8 @@ use haruki_assetstudio_ffi::{AssetStudioFfiObjectReadResponse, AssetStudioFfiRes
 use crate::core::cleanup::remove_file_if_exists;
 use crate::core::codec;
 use crate::core::config::{
-    AppConfig, AssetStudioFfiMode, AudioOutputFormat, ImageBackendConfig, ImageOutputFormat,
-    ImagePngCompression, MediaBackend, RegionConfig, ResourcesConfig,
-    DEFAULT_ASSET_STUDIO_EXPORT_TYPES,
+    AppConfig, AudioOutputFormat, ImageBackendConfig, ImageOutputFormat, ImagePngCompression,
+    MediaBackend, RegionConfig, ResourcesConfig, DEFAULT_ASSET_STUDIO_EXPORT_TYPES,
 };
 use crate::core::errors::ExportPipelineError;
 use crate::core::media::{

--- a/src/core/export_pipeline/implementation/assetstudio.rs
+++ b/src/core/export_pipeline/implementation/assetstudio.rs
@@ -13,19 +13,6 @@ pub(super) async fn run_assetstudio_ffi_object_export(
     strip_path_prefix: &str,
     native_library_path: &str,
 ) -> Result<NativeObjectExportSummary, ExportPipelineError> {
-    if app_config.backends.asset_studio.mode == AssetStudioFfiMode::Direct {
-        return call_assetstudio_ffi_object_export_direct(
-            app_config,
-            region,
-            asset_bundle_file,
-            output_dir,
-            export_path,
-            strip_path_prefix,
-            native_library_path,
-        )
-        .await;
-    }
-
     let worker_path =
         configured_worker_path(app_config.backends.asset_studio.worker_path.as_deref())?;
     let pool = AssetStudioWorkerPool::shared(
@@ -89,137 +76,6 @@ pub(super) async fn run_assetstudio_ffi_object_export(
             .await
         }
         Err(error) => Err(error),
-    }
-}
-
-async fn call_assetstudio_ffi_object_export_direct(
-    app_config: &AppConfig,
-    region: &RegionConfig,
-    asset_bundle_file: &Path,
-    output_dir: &Path,
-    export_path: &str,
-    strip_path_prefix: &str,
-    native_library_path: &str,
-) -> Result<NativeObjectExportSummary, ExportPipelineError> {
-    let wait_started = Instant::now();
-    let cpu_budget_slot = acquire_cpu_budget_permit(app_config.effective_cpu_budget()).await?;
-    let open_request = AssetStudioFfiContextOpenRequest {
-        input_path: asset_bundle_file.to_string_lossy().to_string(),
-        asset_types: asset_studio_export_type_list(region),
-        unity_version: (!region.runtime.unity_version.is_empty())
-            .then(|| region.runtime.unity_version.clone()),
-        filter_exclude_mode: false,
-        filter_with_regex: false,
-        filter_by_name: None,
-        filter_by_container: None,
-        filter_by_path_ids: Vec::new(),
-        load_all_assets: true,
-        include_assets: false,
-    };
-    let options = NativeObjectExportOptions {
-        output_dir,
-        export_path,
-        strip_path_prefix,
-        region,
-        read_kinds: &app_config.backends.asset_studio.read_kinds,
-        image_format: app_config
-            .backends
-            .asset_studio
-            .image_format
-            .as_deref()
-            .unwrap_or(NATIVE_AOT_DEFAULT_IMAGE_FORMAT),
-        read_batch_size: app_config.backends.asset_studio.read_batch_size,
-    };
-    let wait_ms = wait_started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
-    let native_library_path = native_library_path.to_string();
-    let open_request = open_request.clone();
-    let options = NativeObjectExportOptionsOwned::from_options(&options);
-    let result = tokio::task::spawn_blocking(move || {
-        let library = shared_direct_assetstudio_library(&native_library_path)?;
-        let mut caller = DirectAssetStudioCaller {
-            library,
-            call_seq: 0,
-        };
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|source| ExportPipelineError::AssetStudioFfi {
-                message: format!("failed to create assetstudio direct runtime: {source}"),
-            })?;
-        runtime.block_on(call_assetstudio_ffi_object_export_with_caller(
-            &mut caller,
-            &open_request,
-            &options.as_ref(),
-        ))
-    })
-    .await
-    .map_err(|source| ExportPipelineError::AssetStudioFfi {
-        message: format!("assetstudio ffi direct export task failed: {source}"),
-    })?;
-    drop(cpu_budget_slot.permit);
-    let mut summary = result?;
-    summary.phase_ms.insert("direct.wait".to_string(), wait_ms);
-    summary.phase_ms.insert(
-        "direct.cpu_budget_wait".to_string(),
-        cpu_budget_slot.wait_ms,
-    );
-    summary
-        .phase_ms
-        .insert("cpu_budget.wait".to_string(), cpu_budget_slot.wait_ms);
-    Ok(summary)
-}
-
-fn shared_direct_assetstudio_library(
-    native_library_path: &str,
-) -> Result<Arc<LoadedAssetStudioFfiLibrary>, AssetStudioFfiError> {
-    static LIBRARIES: OnceLock<Mutex<HashMap<String, Arc<LoadedAssetStudioFfiLibrary>>>> =
-        OnceLock::new();
-    let mut libraries = LIBRARIES
-        .get_or_init(|| Mutex::new(HashMap::new()))
-        .lock()
-        .unwrap();
-    if let Some(library) = libraries.get(native_library_path) {
-        return Ok(library.clone());
-    }
-    let library = Arc::new(LoadedAssetStudioFfiLibrary::load(native_library_path)?);
-    libraries.insert(native_library_path.to_string(), library.clone());
-    Ok(library)
-}
-
-#[derive(Clone)]
-struct NativeObjectExportOptionsOwned {
-    output_dir: PathBuf,
-    export_path: String,
-    strip_path_prefix: String,
-    region: RegionConfig,
-    read_kinds: BTreeMap<String, String>,
-    image_format: String,
-    read_batch_size: usize,
-}
-
-impl NativeObjectExportOptionsOwned {
-    fn from_options(options: &NativeObjectExportOptions<'_>) -> Self {
-        Self {
-            output_dir: options.output_dir.to_path_buf(),
-            export_path: options.export_path.to_string(),
-            strip_path_prefix: options.strip_path_prefix.to_string(),
-            region: options.region.clone(),
-            read_kinds: options.read_kinds.clone(),
-            image_format: options.image_format.to_string(),
-            read_batch_size: options.read_batch_size,
-        }
-    }
-
-    fn as_ref(&self) -> NativeObjectExportOptions<'_> {
-        NativeObjectExportOptions {
-            output_dir: &self.output_dir,
-            export_path: &self.export_path,
-            strip_path_prefix: &self.strip_path_prefix,
-            region: &self.region,
-            read_kinds: &self.read_kinds,
-            image_format: &self.image_format,
-            read_batch_size: self.read_batch_size,
-        }
     }
 }
 
@@ -316,29 +172,6 @@ impl AssetStudioObjectExportCaller for WorkerLease {
         request: &AssetStudioFfiRequest,
     ) -> Result<WorkerOutput, ExportPipelineError> {
         Ok(WorkerLease::call(self, request).await?)
-    }
-}
-
-struct DirectAssetStudioCaller {
-    library: Arc<LoadedAssetStudioFfiLibrary>,
-    call_seq: u64,
-}
-
-impl AssetStudioObjectExportCaller for DirectAssetStudioCaller {
-    async fn call(
-        &mut self,
-        request: &AssetStudioFfiRequest,
-    ) -> Result<WorkerOutput, ExportPipelineError> {
-        self.call_seq = self.call_seq.saturating_add(1);
-        let (status, response, payload) = self.library.call_typed_request(request)?;
-        Ok(WorkerOutput {
-            status: status.to_string(),
-            status_success: status == 0,
-            response,
-            stderr: String::new(),
-            payload,
-            payload_file: None,
-        })
     }
 }
 
@@ -615,58 +448,6 @@ pub(super) fn is_native_aot_non_bmp_image_read(
     is_native_image_asset(asset) && native_image_format_for_asset(asset, image_format) != "bmp"
 }
 
-#[allow(dead_code)]
-pub(super) fn parse_assetstudio_ffi_object_read_worker_output_recoverable(
-    output: WorkerOutput,
-    asset: &AssetStudioFfiAssetInfo,
-) -> Result<NativeObjectReadParseResult, ExportPipelineError> {
-    let response = output.response.into_object_read()?;
-    for warning in &response.warnings {
-        warn!(warning = %warning, "assetstudio ffi object read warning");
-    }
-    if !(output.status_success && response.success) {
-        let message = response.error.clone().unwrap_or_else(|| {
-            format!(
-                "native context_read_object failed with status {}: {}",
-                output.status,
-                output.stderr.trim()
-            )
-        });
-        warn!(
-            path_id = asset.path_id,
-            asset_type = asset.asset_type.as_deref().unwrap_or(""),
-            name = asset.name.as_deref().unwrap_or(""),
-            error = %message,
-            "assetstudio ffi object read failed; skipping object"
-        );
-        if let Some(payload_file) = output.payload_file {
-            let _ = remove_file_if_exists(&payload_file);
-        }
-        return Ok(NativeObjectReadParseResult::Skipped(
-            NativeSkippedObjectRead {
-                path_id: asset.path_id,
-                asset_type: asset.asset_type.clone(),
-                name: asset.name.clone(),
-                container: asset.container.clone(),
-                error: message,
-            },
-        ));
-    }
-    let payload: bytes::Bytes = if !output.payload.is_empty() {
-        if let Some(payload_file) = output.payload_file {
-            let _ = remove_file_if_exists(&payload_file);
-        }
-        output.payload.into()
-    } else if let Some(payload_file) = output.payload_file {
-        map_spilled_payload(&payload_file)?
-    } else {
-        bytes::Bytes::new()
-    };
-    Ok(NativeObjectReadParseResult::Read(Box::new(
-        AssetStudioFfiObjectReadOutput { response, payload },
-    )))
-}
-
 pub(super) fn select_native_object_readable_assets<'a>(
     assets: &'a [AssetStudioFfiAssetInfo],
     configured_asset_types: &[String],
@@ -844,11 +625,6 @@ pub(super) fn record_native_object_read_batch_diagnostics(
     );
     merge_prefixed_usize_counts(
         &mut summary.phase_ms,
-        "read_batch.asset_type_count",
-        &read_outputs.asset_type_counts,
-    );
-    merge_prefixed_usize_counts(
-        &mut summary.phase_ms,
         "read_batch.payload_kind_count",
         &read_outputs.payload_kind_counts,
     );
@@ -857,21 +633,7 @@ pub(super) fn record_native_object_read_batch_diagnostics(
         "read_batch.payload_bytes_by_kind",
         &read_outputs.payload_bytes_by_kind,
     );
-    for (phase, stats) in &read_outputs.phase_stats {
-        record_max_phase_ms(
-            &mut summary.phase_ms,
-            &format!("read_batch.{phase}.p50"),
-            stats.p50_ms,
-        );
-        record_max_phase_ms(
-            &mut summary.phase_ms,
-            &format!("read_batch.{phase}.p95"),
-            stats.p95_ms,
-        );
-    }
     debug!(
-        worker_id = read_outputs.worker_id.as_deref().unwrap_or(""),
-        call_seq = read_outputs.call_seq,
         requested_objects = asset_chunk.len(),
         response_objects = read_outputs.object_count,
         payload_bundle_version = read_outputs.payload_bundle_version,
@@ -881,7 +643,6 @@ pub(super) fn record_native_object_read_batch_diagnostics(
         failed_reads = read_outputs.failed_count,
         read_payload_ms = read_outputs.read_payload_ms,
         phase_ms = ?read_outputs.phase_ms,
-        asset_type_counts = ?read_outputs.asset_type_counts,
         payload_kind_counts = ?read_outputs.payload_kind_counts,
         payload_bytes_by_kind = ?read_outputs.payload_bytes_by_kind,
         "assetstudio ffi object read batch diagnostics"
@@ -944,13 +705,9 @@ pub(super) fn parse_assetstudio_ffi_object_read_batch_worker_output_recoverable(
                 assets.len()
             },
             read_payload_ms: response.read_payload_ms,
-            worker_id: response.worker_id,
-            call_seq: response.call_seq,
             phase_ms: response.phase_ms,
-            asset_type_counts: response.asset_type_counts,
             payload_kind_counts: response.payload_kind_counts,
             payload_bytes_by_kind: response.payload_bytes_by_kind,
-            phase_stats: response.phase_stats,
         });
     }
 
@@ -983,13 +740,9 @@ pub(super) fn parse_assetstudio_ffi_object_read_batch_worker_output_recoverable(
     let payload_data_bytes = object_read_batch_payload_data_bytes(&response);
     let mut failed_count = response.failed_count;
     let read_payload_ms = response.read_payload_ms;
-    let worker_id = response.worker_id.clone();
-    let call_seq = response.call_seq;
     let phase_ms = response.phase_ms.clone();
-    let asset_type_counts = response.asset_type_counts.clone();
     let payload_kind_counts = response.payload_kind_counts.clone();
     let payload_bytes_by_kind = response.payload_bytes_by_kind.clone();
-    let phase_stats = response.phase_stats.clone();
     let mut observed_failed_count = 0usize;
     let mut results = Vec::with_capacity(assets.len());
     for (asset, read_response) in assets.iter().zip(response.reads) {
@@ -1048,13 +801,9 @@ pub(super) fn parse_assetstudio_ffi_object_read_batch_worker_output_recoverable(
         payload_data_bytes,
         failed_count,
         read_payload_ms,
-        worker_id,
-        call_seq,
         phase_ms,
-        asset_type_counts,
         payload_kind_counts,
         payload_bytes_by_kind,
-        phase_stats,
     })
 }
 

--- a/src/core/export_pipeline/implementation/assetstudio.rs
+++ b/src/core/export_pipeline/implementation/assetstudio.rs
@@ -764,7 +764,30 @@ pub(super) fn native_object_read_batch_request(
                 image_format: native_image_format_for_asset(asset, image_format),
             })
             .collect(),
+        payload_capacity_hint: native_object_read_payload_capacity_hint(asset_chunk, image_format),
     }
+}
+
+/// Generous upper bound for the batch's packed payload block. Images decode from
+/// compressed GPU formats to raw RGBA (up to ~16x for ASTC 8x8), other kinds stay
+/// close to their source size. The spill file backing this reservation is sparse,
+/// so overestimating is free; underestimating only costs one fallback copy in the
+/// worker.
+pub(super) fn native_object_read_payload_capacity_hint(
+    asset_chunk: &[&AssetStudioFfiAssetInfo],
+    image_format: &str,
+) -> u64 {
+    asset_chunk
+        .iter()
+        .map(|asset| {
+            let size = asset.size.max(0) as u64;
+            if is_native_aot_non_bmp_image_read(asset, image_format) {
+                size.saturating_mul(16).saturating_add(1024 * 1024)
+            } else {
+                size.saturating_mul(2).saturating_add(64 * 1024)
+            }
+        })
+        .fold(0u64, u64::saturating_add)
 }
 
 pub(super) fn native_image_format_for_asset(

--- a/src/core/export_pipeline/implementation/assetstudio.rs
+++ b/src/core/export_pipeline/implementation/assetstudio.rs
@@ -440,6 +440,16 @@ where
                             read_output
                         }
                         NativeObjectReadParseResult::Skipped(skipped) => {
+                            // A skipped read is data loss for this object; without the
+                            // warning a systematic failure (e.g. a native dependency
+                            // that cannot load) is invisible outside summary metadata.
+                            warn!(
+                                path_id = skipped.path_id,
+                                asset_type = skipped.asset_type.as_deref().unwrap_or(""),
+                                name = skipped.name.as_deref().unwrap_or(""),
+                                error = %skipped.error,
+                                "assetstudio ffi object read failed; skipping object"
+                            );
                             summary.skipped_object_reads.push(skipped);
                             summary.object_read_plan.skipped_reads += 1;
                             continue;

--- a/src/core/export_pipeline/implementation/assetstudio.rs
+++ b/src/core/export_pipeline/implementation/assetstudio.rs
@@ -642,26 +642,18 @@ pub(super) fn parse_assetstudio_ffi_object_read_worker_output_recoverable(
             },
         ));
     }
-    let payload = if !output.payload.is_empty() {
+    let payload: bytes::Bytes = if !output.payload.is_empty() {
         if let Some(payload_file) = output.payload_file {
             let _ = remove_file_if_exists(&payload_file);
         }
-        output.payload
+        output.payload.into()
     } else if let Some(payload_file) = output.payload_file {
-        let payload = std::fs::read(&payload_file).map_err(|source| ExportPipelineError::Io {
-            path: payload_file.clone(),
-            source,
-        })?;
-        let _ = remove_file_if_exists(&payload_file);
-        payload
+        map_spilled_payload(&payload_file)?
     } else {
-        Vec::new()
+        bytes::Bytes::new()
     };
     Ok(NativeObjectReadParseResult::Read(Box::new(
-        AssetStudioFfiObjectReadOutput {
-            response,
-            payload: payload.into(),
-        },
+        AssetStudioFfiObjectReadOutput { response, payload },
     )))
 }
 
@@ -872,20 +864,18 @@ pub(super) fn parse_assetstudio_ffi_object_read_batch_worker_output_recoverable(
         warn!(warning = %warning, "assetstudio ffi object read batch warning");
     }
 
-    let payload = if !output.payload.is_empty() {
+    let payload: bytes::Bytes = if !output.payload.is_empty() {
         if let Some(payload_file) = output.payload_file {
             let _ = remove_file_if_exists(&payload_file);
         }
-        output.payload
+        output.payload.into()
     } else if let Some(payload_file) = output.payload_file {
-        let payload = std::fs::read(&payload_file).map_err(|source| ExportPipelineError::Io {
-            path: payload_file.clone(),
-            source,
-        })?;
-        let _ = remove_file_if_exists(&payload_file);
-        payload
+        // Spilled payloads are mapped, not read: the worker wrote them into tmpfs
+        // (when available) and the mapping is shared straight through to the
+        // per-object Bytes slices and the image encoders.
+        map_spilled_payload(&payload_file)?
     } else {
-        Vec::new()
+        bytes::Bytes::new()
     };
 
     if !(output.status_success && response.success) && response.reads.len() != assets.len() {
@@ -941,11 +931,10 @@ pub(super) fn parse_assetstudio_ffi_object_read_batch_worker_output_recoverable(
         });
     }
 
-    // Wrap the bundle once; per-object payloads become refcounted sub-slices of it
-    // instead of per-object heap copies. Images are sub-chunked into single-object
-    // batches upstream, so a retained image slice pins a bundle of roughly its own
-    // size rather than a large mixed batch.
-    let payload = bytes::Bytes::from(payload);
+    // Per-object payloads become refcounted sub-slices of the bundle instead of
+    // per-object heap copies. Images are sub-chunked into single-object batches
+    // upstream, so a retained image slice pins a bundle of roughly its own size
+    // rather than a large mixed batch.
     let payloads = if payload.is_empty() {
         HashMap::new()
     } else {

--- a/src/core/export_pipeline/implementation/assetstudio.rs
+++ b/src/core/export_pipeline/implementation/assetstudio.rs
@@ -447,7 +447,13 @@ where
                     };
                     merge_phase_ms(&mut summary.phase_ms, &read_output.response.phase_ms);
                     if is_playable_mono_typetree(asset, &read_output) {
-                        playable_outputs.push(((*asset).clone(), (*read_output).clone()));
+                        // Deep-copy the (small) typetree payload: playable outputs are
+                        // held until the end of the path export and must not pin the
+                        // whole read-batch bundle their Bytes slice points into.
+                        let mut playable_output = (*read_output).clone();
+                        playable_output.payload =
+                            bytes::Bytes::from(playable_output.payload.to_vec());
+                        playable_outputs.push(((*asset).clone(), playable_output));
                     } else {
                         write_native_object_payload(options, &mut path_state, asset, &read_output)?;
                     }
@@ -652,7 +658,10 @@ pub(super) fn parse_assetstudio_ffi_object_read_worker_output_recoverable(
         Vec::new()
     };
     Ok(NativeObjectReadParseResult::Read(Box::new(
-        AssetStudioFfiObjectReadOutput { response, payload },
+        AssetStudioFfiObjectReadOutput {
+            response,
+            payload: payload.into(),
+        },
     )))
 }
 
@@ -932,10 +941,15 @@ pub(super) fn parse_assetstudio_ffi_object_read_batch_worker_output_recoverable(
         });
     }
 
+    // Wrap the bundle once; per-object payloads become refcounted sub-slices of it
+    // instead of per-object heap copies. Images are sub-chunked into single-object
+    // batches upstream, so a retained image slice pins a bundle of roughly its own
+    // size rather than a large mixed batch.
+    let payload = bytes::Bytes::from(payload);
     let payloads = if payload.is_empty() {
         HashMap::new()
     } else {
-        parse_payload_bundle_borrowed(&payload)?
+        parse_payload_bundle_shared(&payload)?
             .into_iter()
             .collect::<HashMap<_, _>>()
     };
@@ -989,7 +1003,7 @@ pub(super) fn parse_assetstudio_ffi_object_read_batch_worker_output_recoverable(
 
         let object_payload = payloads
             .get(&asset.path_id.to_string())
-            .map(|payload| payload.to_vec())
+            .cloned()
             .unwrap_or_default();
         results.push(NativeObjectReadParseResult::Read(Box::new(
             AssetStudioFfiObjectReadOutput {

--- a/src/core/export_pipeline/implementation/limits.rs
+++ b/src/core/export_pipeline/implementation/limits.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-#[allow(dead_code)]
 pub(super) struct CpuBudgetAcquire {
     pub(super) permit: CpuBudgetPermit,
     pub(super) wait_ms: u64,

--- a/src/core/export_pipeline/implementation/media_postprocess.rs
+++ b/src/core/export_pipeline/implementation/media_postprocess.rs
@@ -779,28 +779,6 @@ pub(super) fn write_usm_streams(
     Ok(generated)
 }
 
-#[allow(dead_code)]
-pub(super) async fn process_usm_file_with_metrics(
-    usm_file: &Path,
-    export_path: &Path,
-    region: &RegionConfig,
-    ffmpeg_path: &str,
-    media_backend: MediaBackend,
-    retry: &crate::core::config::RetryConfig,
-) -> Result<UsmPostProcessOutput, ExportPipelineError> {
-    process_usm_input_with_metrics(
-        &UsmProcessingInput::Path(usm_file.to_path_buf()),
-        export_path,
-        region,
-        ffmpeg_path,
-        media_backend,
-        retry,
-        1,
-        1,
-    )
-    .await
-}
-
 pub(super) fn handle_acb_files_owned(
     options: &OwnedAcbPostProcessOptions,
     acb_concurrency: usize,

--- a/src/core/export_pipeline/implementation/payload.rs
+++ b/src/core/export_pipeline/implementation/payload.rs
@@ -899,7 +899,7 @@ pub(super) fn safe_payload_bundle_path(name: &str) -> PathBuf {
     }
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
 pub(super) fn parse_payload_bundle(
     payload: &[u8],
 ) -> Result<Vec<(String, Vec<u8>)>, ExportPipelineError> {
@@ -1046,19 +1046,7 @@ pub(super) fn parse_payload_bundle_borrowed(
     if payload.starts_with(NATIVE_AOT_PAYLOAD_BUNDLE_MAGIC) {
         cursor += NATIVE_AOT_PAYLOAD_BUNDLE_MAGIC.len();
         let count = read_bundle_u32(payload, &mut cursor)? as usize;
-        match parse_payload_bundle_grouped_entries(payload, cursor, count) {
-            Ok(entries) => return Ok(entries),
-            Err(grouped_error) => {
-                return parse_payload_bundle_interleaved_entries(payload, cursor, count, None)
-                    .map_err(|interleaved_error| ExportPipelineError::AssetStudioFfi {
-                        message: format!(
-                            "{}; legacy grouped parse also failed: {}",
-                            assetstudio_error_message(&interleaved_error),
-                            assetstudio_error_message(&grouped_error)
-                        ),
-                    });
-            }
-        }
+        return parse_payload_bundle_grouped_entries(payload, cursor, count);
     }
 
     Err(ExportPipelineError::AssetStudioFfi {
@@ -1178,13 +1166,6 @@ pub(super) fn finish_payload_bundle_parse(
         }
     }
     Ok(())
-}
-
-pub(super) fn assetstudio_error_message(error: &ExportPipelineError) -> String {
-    match error {
-        ExportPipelineError::AssetStudioFfi { message } => message.clone(),
-        other => other.to_string(),
-    }
 }
 
 pub(super) fn read_bundle_u32(

--- a/src/core/export_pipeline/implementation/payload.rs
+++ b/src/core/export_pipeline/implementation/payload.rs
@@ -56,7 +56,9 @@ pub(super) fn write_native_object_payload(
     if is_text_asset_acb_target(asset, &target) {
         path_state.acb_sources.push(NativeInMemoryMediaSource {
             target: target.clone(),
-            payload: read_output.payload.clone(),
+            // Deliberate copy: ACB sources outlive the whole export into the media
+            // post-process stage, so they must not pin the read-batch bundle.
+            payload: read_output.payload.to_vec(),
         });
         return Ok(());
     }
@@ -76,7 +78,7 @@ pub(super) fn write_native_object_payload(
         queue_native_image_payload_final_files(
             path_state,
             &target,
-            &read_output.payload,
+            read_output.payload.clone(),
             options.region,
         )
     } else {
@@ -522,7 +524,7 @@ pub(super) fn write_native_payload_file(
 pub(super) fn queue_native_image_payload_final_files(
     path_state: &mut NativeSemanticExportPathState,
     target: &Path,
-    payload: &[u8],
+    payload: bytes::Bytes,
     region: &RegionConfig,
 ) -> Vec<PathBuf> {
     let written_files = planned_image_output_files(target, region);
@@ -530,7 +532,7 @@ pub(super) fn queue_native_image_payload_final_files(
         .pending_image_writes
         .push(PendingNativeImageWrite {
             target: target.to_path_buf(),
-            payload: payload.to_vec(),
+            payload,
             region: region.clone(),
         });
     written_files
@@ -850,10 +852,10 @@ pub(super) fn write_payload_bundle(
 pub(super) fn queue_native_image_payload_bundle_final_files(
     path_state: &mut NativeSemanticExportPathState,
     target: &Path,
-    payload: &[u8],
+    payload: &bytes::Bytes,
     region: &RegionConfig,
 ) -> Result<Vec<PathBuf>, ExportPipelineError> {
-    let entries = parse_payload_bundle_borrowed(payload)?;
+    let entries = parse_payload_bundle_shared(payload)?;
     let mut written_files = Vec::with_capacity(entries.len());
     for (name, bytes) in entries {
         let entry_target = payload_bundle_entry_target(target, &name).with_extension("png");
@@ -904,6 +906,23 @@ pub(super) fn parse_payload_bundle(
     Ok(parse_payload_bundle_borrowed(payload)?
         .into_iter()
         .map(|(name, bytes)| (name, bytes.to_vec()))
+        .collect())
+}
+
+/// Bundle parse that returns refcounted sub-slices of the backing buffer instead
+/// of borrowed slices, so entries can outlive the parse without a heap copy.
+pub(super) fn parse_payload_bundle_shared(
+    payload: &bytes::Bytes,
+) -> Result<Vec<(String, bytes::Bytes)>, ExportPipelineError> {
+    let base = payload.as_ptr() as usize;
+    Ok(parse_payload_bundle_borrowed(payload)?
+        .into_iter()
+        .map(|(name, slice)| {
+            // Sub-slices returned by the borrowed parser always point inside
+            // `payload`, so the offset arithmetic cannot underflow or overflow.
+            let start = slice.as_ptr() as usize - base;
+            (name, payload.slice(start..start + slice.len()))
+        })
         .collect())
 }
 

--- a/src/core/export_pipeline/implementation/payload.rs
+++ b/src/core/export_pipeline/implementation/payload.rs
@@ -909,6 +909,91 @@ pub(super) fn parse_payload_bundle(
         .collect())
 }
 
+/// A read-only mmap of a worker payload spill file. The file is unlinked right
+/// after mapping; the pages (and therefore every `Bytes` slice into them) stay
+/// valid until the mapping drops.
+#[cfg(unix)]
+struct MappedSpilledPayload {
+    pointer: *mut libc::c_void,
+    len: usize,
+}
+
+// SAFETY: the mapping is PROT_READ and never mutated; concurrent reads from any
+// thread are safe, and munmap happens exactly once in Drop.
+#[cfg(unix)]
+unsafe impl Send for MappedSpilledPayload {}
+#[cfg(unix)]
+unsafe impl Sync for MappedSpilledPayload {}
+
+#[cfg(unix)]
+impl AsRef<[u8]> for MappedSpilledPayload {
+    fn as_ref(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.pointer as *const u8, self.len) }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for MappedSpilledPayload {
+    fn drop(&mut self) {
+        unsafe {
+            libc::munmap(self.pointer, self.len);
+        }
+    }
+}
+
+/// Loads a worker payload spill file as shared `Bytes` and removes the file. On unix
+/// the file is mapped instead of read, so the parent-side heap copy of the payload
+/// disappears; when the worker spilled into tmpfs the bytes never touch disk at all.
+pub(super) fn map_spilled_payload(path: &Path) -> Result<bytes::Bytes, ExportPipelineError> {
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+
+        let io_error = |source| ExportPipelineError::Io {
+            path: path.to_path_buf(),
+            source,
+        };
+        let file = std::fs::File::open(path).map_err(io_error)?;
+        let len = file.metadata().map_err(io_error)?.len();
+        if len == 0 {
+            drop(file);
+            let _ = std::fs::remove_file(path);
+            return Ok(bytes::Bytes::new());
+        }
+        let mapped = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                len as usize,
+                libc::PROT_READ,
+                libc::MAP_PRIVATE,
+                file.as_raw_fd(),
+                0,
+            )
+        };
+        drop(file);
+        if mapped == libc::MAP_FAILED {
+            // Extremely defensive: fall back to a plain read if the mapping fails.
+            let payload = std::fs::read(path).map_err(io_error)?;
+            let _ = std::fs::remove_file(path);
+            return Ok(payload.into());
+        }
+        let _ = std::fs::remove_file(path);
+        Ok(bytes::Bytes::from_owner(MappedSpilledPayload {
+            pointer: mapped,
+            len: len as usize,
+        }))
+    }
+    #[cfg(not(unix))]
+    {
+        let payload = std::fs::read(path).map_err(|source| ExportPipelineError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let _ = std::fs::remove_file(path);
+        Ok(payload.into())
+    }
+}
+
 /// Bundle parse that returns refcounted sub-slices of the backing buffer instead
 /// of borrowed slices, so entries can outlive the parse without a heap copy.
 pub(super) fn parse_payload_bundle_shared(

--- a/src/core/export_pipeline/implementation/tests.rs
+++ b/src/core/export_pipeline/implementation/tests.rs
@@ -2661,6 +2661,56 @@ fn object_read_batch_preserves_diagnostics_and_payloads() {
 }
 
 #[test]
+fn object_read_batch_maps_spilled_payload_file_and_removes_it() {
+    let asset = AssetStudioFfiAssetInfo {
+        index: 0,
+        name: Some("ok".to_string()),
+        container: Some("assets/ok.bytes".to_string()),
+        asset_type: Some("TextAsset".to_string()),
+        type_id: 49,
+        path_id: 7,
+        unique_id: None,
+        size: 3,
+        source_file: None,
+    };
+    let mut payload = Vec::new();
+    payload.extend_from_slice(super::NATIVE_AOT_PAYLOAD_BUNDLE_MAGIC);
+    payload.extend_from_slice(&1u32.to_le_bytes());
+    payload.extend_from_slice(&1u32.to_le_bytes());
+    payload.extend_from_slice(&3u64.to_le_bytes());
+    payload.extend_from_slice(b"7");
+    payload.extend_from_slice(b"abc");
+    let spill_dir = tempfile::tempdir().unwrap();
+    let payload_file = spill_dir.path().join("spilled-payload.bin");
+    std::fs::write(&payload_file, &payload).unwrap();
+    let output = WorkerOutput {
+            status: "0".to_string(),
+            status_success: true,
+            response: AssetStudioFfiResponse::ContextReadObjects(
+                sonic_rs::from_str(r#"{"success":true,"reads":[{"success":true,"asset":{"index":0,"name":"ok","container":"assets/ok.bytes","asset_type":"TextAsset","type_id":49,"path_id":7,"size":3,"source_file":null},"payload_kind":"text_bytes","payload_len":3,"suggested_extension":".bytes","warnings":[],"phase_ms":{},"error":null,"duration_ms":1}],"warnings":[],"payload_len":3,"object_count":1,"payload_bundle_bytes":0,"failed_count":0,"read_payload_ms":1,"worker_id":null,"call_seq":null,"phase_stats":{},"error":null,"duration_ms":1}"#).unwrap(),
+            ),
+            stderr: String::new(),
+            payload: Vec::new(),
+            payload_file: Some(payload_file.clone()),
+        };
+    let assets = [&asset];
+
+    let parsed =
+        parse_assetstudio_ffi_object_read_batch_worker_output_recoverable(output, &assets).unwrap();
+
+    assert_eq!(parsed.results.len(), 1);
+    let NativeObjectReadParseResult::Read(read) = &parsed.results[0] else {
+        panic!("expected successful batch object read");
+    };
+    // The payload slice is served straight from the (already unlinked) mapping.
+    assert_eq!(read.payload.as_ref(), b"abc");
+    assert!(
+        !payload_file.exists(),
+        "spilled payload file should be removed after mapping"
+    );
+}
+
+#[test]
 fn object_read_batch_diagnostics_record_max_phase_stats() {
     let asset = AssetStudioFfiAssetInfo {
         index: 0,

--- a/src/core/export_pipeline/implementation/tests.rs
+++ b/src/core/export_pipeline/implementation/tests.rs
@@ -846,7 +846,7 @@ fn native_image_object_payload_is_flushed_after_export_queue() {
             error: None,
             duration_ms: None,
         },
-        payload,
+        payload: payload.into(),
     };
 
     write_native_object_payload(&options, &mut path_state, &asset, &read_output).unwrap();
@@ -905,7 +905,7 @@ fn text_asset_acb_payload_is_queued_as_memory_source_without_writing_file() {
             error: None,
             duration_ms: None,
         },
-        payload: b"acb!".to_vec(),
+        payload: bytes::Bytes::from_static(b"acb!"),
     };
 
     write_native_object_payload(&options, &mut path_state, &asset, &read_output).unwrap();
@@ -965,7 +965,7 @@ fn music_score_text_asset_manifest_uses_public_txt_extension() {
             error: None,
             duration_ms: None,
         },
-        payload: b"score".to_vec(),
+        payload: bytes::Bytes::from_static(b"score"),
     };
 
     write_native_object_payload(&options, &mut path_state, &asset, &read_output).unwrap();
@@ -1033,7 +1033,7 @@ fn decoded_usm_text_asset_is_not_recorded_as_final_manifest_entry() {
             error: None,
             duration_ms: None,
         },
-        payload: b"usm!".to_vec(),
+        payload: bytes::Bytes::from_static(b"usm!"),
     };
 
     write_native_object_payload(&options, &mut path_state, &asset, &read_output).unwrap();
@@ -1097,7 +1097,7 @@ fn assetbundle_typetree_routes_to_container_bundle_record_path() {
             error: None,
             duration_ms: None,
         },
-        payload: payload.to_vec(),
+        payload: payload.to_vec().into(),
     };
 
     write_native_object_payload(&options, &mut path_state, &asset, &read_output).unwrap();
@@ -1167,7 +1167,7 @@ fn assetbundle_typetree_mixed_categories_use_stable_bundle_fallback_path() {
             error: None,
             duration_ms: None,
         },
-        payload: payload.to_vec(),
+        payload: payload.to_vec().into(),
     };
 
     write_native_object_payload(&options, &mut path_state, &asset, &read_output).unwrap();
@@ -1228,7 +1228,7 @@ fn monoscript_typetree_routes_to_container_subasset_path() {
             error: None,
             duration_ms: None,
         },
-        payload: payload.to_vec(),
+        payload: payload.to_vec().into(),
     };
 
     write_native_object_payload(&options, &mut path_state, &asset, &read_output).unwrap();
@@ -1778,7 +1778,7 @@ fn manifest_records_native_surrogate_image_public_png_path() {
             error: None,
             duration_ms: None,
         },
-        payload: Vec::new(),
+        payload: bytes::Bytes::new(),
     };
 
     write_assetstudio_export_manifest_entry(dir.path(), &target, &asset, &read_output).unwrap();
@@ -1835,7 +1835,7 @@ fn manifest_records_animator_bundle_public_fbx_path() {
             error: None,
             duration_ms: None,
         },
-        payload,
+        payload: payload.into(),
     };
 
     write_assetstudio_export_manifest_entry(dir.path(), &target, &asset, &read_output).unwrap();
@@ -2025,7 +2025,7 @@ fn native_object_export_skips_byte_identical_semantic_duplicates() {
             error: None,
             duration_ms: None,
         },
-        payload: br#"{"m_Name":"004026_shiho01"}"#.to_vec(),
+        payload: bytes::Bytes::from_static(br#"{"m_Name":"004026_shiho01"}"#),
     };
 
     write_native_object_payload(&options, &mut path_state, &asset, &read_output).unwrap();
@@ -2087,11 +2087,11 @@ fn native_object_export_keeps_distinct_semantic_duplicates() {
             error: None,
             duration_ms: None,
         },
-        payload: br#"{"m_GameObject":1}"#.to_vec(),
+        payload: bytes::Bytes::from_static(br#"{"m_GameObject":1}"#),
     };
 
     write_native_object_payload(&options, &mut path_state, &asset, &read_output).unwrap();
-    read_output.payload = br#"{"m_GameObject":2}"#.to_vec();
+    read_output.payload = bytes::Bytes::from_static(br#"{"m_GameObject":2}"#);
     write_native_object_payload(&options, &mut path_state, &asset, &read_output).unwrap();
 
     let first = dir
@@ -2548,7 +2548,7 @@ fn object_read_prefers_in_memory_worker_payload() {
     let NativeObjectReadParseResult::Read(read) = parsed else {
         panic!("expected successful object read");
     };
-    assert_eq!(read.payload, b"abc");
+    assert_eq!(read.payload.as_ref(), b"abc");
     assert_eq!(read.response.payload_len, 3);
 }
 
@@ -2584,7 +2584,7 @@ fn object_read_loads_payload_file_and_removes_it() {
     let NativeObjectReadParseResult::Read(read) = parsed else {
         panic!("expected successful object read");
     };
-    assert_eq!(read.payload, b"abc");
+    assert_eq!(read.payload.as_ref(), b"abc");
     assert!(!payload_file.exists());
 }
 
@@ -2651,7 +2651,7 @@ fn object_read_batch_preserves_diagnostics_and_payloads() {
     let NativeObjectReadParseResult::Read(read) = &parsed.results[0] else {
         panic!("expected successful batch object read");
     };
-    assert_eq!(read.payload, b"abc");
+    assert_eq!(read.payload.as_ref(), b"abc");
     assert_eq!(read.response.payload_len, 3);
     let NativeObjectReadParseResult::Skipped(skipped) = &parsed.results[1] else {
         panic!("expected skipped batch object read");

--- a/src/core/export_pipeline/implementation/tests.rs
+++ b/src/core/export_pipeline/implementation/tests.rs
@@ -27,8 +27,7 @@ use super::{
     native_object_output_extension, native_object_output_path, native_read_batch_size_for_assets,
     native_read_kind_for_asset, native_skipped_unsupported_asset,
     parse_assetstudio_ffi_context_list_objects_worker_output,
-    parse_assetstudio_ffi_object_read_batch_worker_output_recoverable,
-    parse_assetstudio_ffi_object_read_worker_output_recoverable, parse_payload_bundle,
+    parse_assetstudio_ffi_object_read_batch_worker_output_recoverable, parse_payload_bundle,
     parse_payload_bundle_borrowed, playable_container_output_path, post_process_exported_files,
     prepare_usm_processing_inputs, process_usm_file, process_usm_input_with_metrics,
     record_native_object_read_batch_diagnostics, run_path_tasks, safe_payload_bundle_path,
@@ -38,11 +37,11 @@ use super::{
     write_native_image_payload_final_files, write_native_image_payload_final_files_with_backend,
     write_native_object_payload, AssetStudioFfiAssetInfo, AssetStudioFfiObjectReadOutput,
     AssetStudioFfiObjectReadResponse, AssetStudioFfiResponse, MediaEncodeKind,
-    NativeBatchPhaseStats, NativeObjectExportOptions, NativeObjectExportSummary,
-    NativeObjectReadBatchParseOutput, NativeObjectReadParseResult, NativeObjectReadPlanStats,
+    NativeObjectExportOptions, NativeObjectExportSummary, NativeObjectReadBatchParseOutput,
+    NativeObjectReadParseResult, NativeObjectReadPlanStats,
     NativeSemanticExportPathState, UsmProcessingInput, WorkerOutput,
     ASSETSTUDIO_MAX_PUBLIC_FILE_STEM_CHARS, NATIVE_AOT_DEFAULT_IMAGE_FORMAT,
-    NATIVE_AOT_FAST_IMAGE_FORMAT, NATIVE_AOT_IMAGE_SURROGATE_FORMAT,
+    NATIVE_AOT_IMAGE_SURROGATE_FORMAT,
 };
 
 fn sample_path(name: &str) -> Option<PathBuf> {
@@ -524,10 +523,6 @@ fn png_to_webp_uses_pure_rust_encoder() {
 #[test]
 fn native_aot_default_image_format_preserves_alpha() {
     assert_eq!(NATIVE_AOT_DEFAULT_IMAGE_FORMAT, "raw_rgba");
-    assert_eq!(
-        NATIVE_AOT_FAST_IMAGE_FORMAT,
-        NATIVE_AOT_DEFAULT_IMAGE_FORMAT
-    );
     assert_eq!(NATIVE_AOT_IMAGE_SURROGATE_FORMAT, "bmp");
 }
 
@@ -2213,28 +2208,6 @@ fn assetstudio_type_names_accept_short_and_class_aliases() {
 }
 
 #[test]
-fn native_payload_bundle_parser_reads_multiple_entries() {
-    let mut payload = Vec::new();
-    payload.extend_from_slice(super::NATIVE_AOT_PAYLOAD_BUNDLE_MAGIC);
-    payload.extend_from_slice(&2u32.to_le_bytes());
-    payload.extend_from_slice(&("layer_0000.bmp".len() as u32).to_le_bytes());
-    payload.extend_from_slice(&3u64.to_le_bytes());
-    payload.extend_from_slice(b"layer_0000.bmp");
-    payload.extend_from_slice(b"one");
-    payload.extend_from_slice(&("nested/layer_0001.bmp".len() as u32).to_le_bytes());
-    payload.extend_from_slice(&3u64.to_le_bytes());
-    payload.extend_from_slice(b"nested/layer_0001.bmp");
-    payload.extend_from_slice(b"two");
-
-    let entries = parse_payload_bundle(&payload).unwrap();
-    assert_eq!(entries.len(), 2);
-    assert_eq!(entries[0].0, "layer_0000.bmp");
-    assert_eq!(entries[0].1, b"one");
-    assert_eq!(entries[1].0, "nested/layer_0001.bmp");
-    assert_eq!(entries[1].1, b"two");
-}
-
-#[test]
 fn native_payload_bundle_parser_reads_v2_header() {
     let mut payload = Vec::new();
     payload.extend_from_slice(&super::NATIVE_AOT_PAYLOAD_BUNDLE_V2_MAGIC.to_le_bytes());
@@ -2485,110 +2458,6 @@ fn context_list_objects_worker_output_parses_pages() {
 }
 
 #[test]
-fn object_read_failure_is_recoverable_for_single_asset() {
-    let asset = AssetStudioFfiAssetInfo {
-        index: 0,
-        name: Some("bad".to_string()),
-        container: None,
-        asset_type: Some("Shader".to_string()),
-        type_id: 48,
-        path_id: 42,
-        unique_id: None,
-        size: 0,
-        source_file: None,
-    };
-    let output = WorkerOutput {
-            status: "100".to_string(),
-            status_success: false,
-            response: AssetStudioFfiResponse::ContextReadObject(
-                sonic_rs::from_str(r#"{"success":false,"asset":null,"payload_kind":null,"payload_len":0,"suggested_extension":null,"warnings":[],"phase_ms":{},"error":"boom","duration_ms":1}"#).unwrap(),
-            ),
-            stderr: String::new(),
-            payload: Vec::new(),
-            payload_file: None,
-        };
-
-    let parsed =
-        parse_assetstudio_ffi_object_read_worker_output_recoverable(output, &asset).unwrap();
-    let NativeObjectReadParseResult::Skipped(skipped) = parsed else {
-        panic!("expected skipped object read");
-    };
-    assert_eq!(skipped.path_id, 42);
-    assert_eq!(skipped.asset_type.as_deref(), Some("Shader"));
-    assert_eq!(skipped.name.as_deref(), Some("bad"));
-    assert_eq!(skipped.error, "boom");
-}
-
-#[test]
-fn object_read_prefers_in_memory_worker_payload() {
-    let asset = AssetStudioFfiAssetInfo {
-        index: 0,
-        name: Some("ok".to_string()),
-        container: None,
-        asset_type: Some("TextAsset".to_string()),
-        type_id: 49,
-        path_id: 7,
-        unique_id: None,
-        size: 3,
-        source_file: None,
-    };
-    let output = WorkerOutput {
-            status: "0".to_string(),
-            status_success: true,
-            response: AssetStudioFfiResponse::ContextReadObject(
-                sonic_rs::from_str(r#"{"success":true,"asset":{"index":0,"name":"ok","container":null,"asset_type":"TextAsset","type_id":49,"path_id":7,"size":3,"source_file":null},"payload_kind":"text_bytes","payload_len":3,"suggested_extension":".bytes","warnings":[],"phase_ms":{},"error":null,"duration_ms":1}"#).unwrap(),
-            ),
-            stderr: String::new(),
-            payload: b"abc".to_vec(),
-            payload_file: None,
-        };
-
-    let parsed =
-        parse_assetstudio_ffi_object_read_worker_output_recoverable(output, &asset).unwrap();
-    let NativeObjectReadParseResult::Read(read) = parsed else {
-        panic!("expected successful object read");
-    };
-    assert_eq!(read.payload.as_ref(), b"abc");
-    assert_eq!(read.response.payload_len, 3);
-}
-
-#[test]
-fn object_read_loads_payload_file_and_removes_it() {
-    let dir = tempdir().unwrap();
-    let payload_file = dir.path().join("payload.bin");
-    fs::write(&payload_file, b"abc").unwrap();
-    let asset = AssetStudioFfiAssetInfo {
-        index: 0,
-        name: Some("ok".to_string()),
-        container: None,
-        asset_type: Some("TextAsset".to_string()),
-        type_id: 49,
-        path_id: 7,
-        unique_id: None,
-        size: 3,
-        source_file: None,
-    };
-    let output = WorkerOutput {
-            status: "0".to_string(),
-            status_success: true,
-            response: AssetStudioFfiResponse::ContextReadObject(
-                sonic_rs::from_str(r#"{"success":true,"asset":{"index":0,"name":"ok","container":null,"asset_type":"TextAsset","type_id":49,"path_id":7,"size":3,"source_file":null},"payload_kind":"text_bytes","payload_len":3,"suggested_extension":".bytes","warnings":[],"phase_ms":{},"error":null,"duration_ms":1}"#).unwrap(),
-            ),
-            stderr: String::new(),
-            payload: Vec::new(),
-            payload_file: Some(payload_file.clone()),
-        };
-
-    let parsed =
-        parse_assetstudio_ffi_object_read_worker_output_recoverable(output, &asset).unwrap();
-    let NativeObjectReadParseResult::Read(read) = parsed else {
-        panic!("expected successful object read");
-    };
-    assert_eq!(read.payload.as_ref(), b"abc");
-    assert!(!payload_file.exists());
-}
-
-#[test]
 fn object_read_batch_preserves_diagnostics_and_payloads() {
     let good_asset = AssetStudioFfiAssetInfo {
         index: 0,
@@ -2623,7 +2492,7 @@ fn object_read_batch_preserves_diagnostics_and_payloads() {
             status: "0".to_string(),
             status_success: true,
             response: AssetStudioFfiResponse::ContextReadObjects(
-                sonic_rs::from_str(r#"{"success":true,"reads":[{"success":true,"asset":{"index":0,"name":"ok","container":"assets/ok.bytes","asset_type":"TextAsset","type_id":49,"path_id":7,"size":3,"source_file":null},"payload_kind":"text_bytes","payload_len":3,"suggested_extension":".bytes","warnings":[],"phase_ms":{"read_object.read_payload":4},"error":null,"duration_ms":5},{"success":false,"asset":null,"payload_kind":null,"payload_len":0,"suggested_extension":null,"warnings":[],"phase_ms":{},"error":"shader unsupported","duration_ms":1}],"warnings":["batch warning"],"payload_len":3,"object_count":2,"payload_bundle_bytes":123,"failed_count":1,"read_payload_ms":4,"worker_id":"worker-a","call_seq":42,"phase_stats":{"read_payload":{"p50_ms":2,"p95_ms":7}},"error":null,"duration_ms":6}"#).unwrap(),
+                sonic_rs::from_str(r#"{"success":true,"reads":[{"success":true,"asset":{"index":0,"name":"ok","container":"assets/ok.bytes","asset_type":"TextAsset","type_id":49,"path_id":7,"size":3,"source_file":null},"payload_kind":"text_bytes","payload_len":3,"suggested_extension":".bytes","warnings":[],"phase_ms":{"read_object.read_payload":4},"error":null,"duration_ms":5},{"success":false,"asset":null,"payload_kind":null,"payload_len":0,"suggested_extension":null,"warnings":[],"phase_ms":{},"error":"shader unsupported","duration_ms":1}],"warnings":["batch warning"],"payload_len":3,"object_count":2,"payload_bundle_bytes":123,"failed_count":1,"read_payload_ms":4,"error":null,"duration_ms":6}"#).unwrap(),
             ),
             stderr: String::new(),
             payload,
@@ -2638,15 +2507,6 @@ fn object_read_batch_preserves_diagnostics_and_payloads() {
     assert_eq!(parsed.payload_bundle_bytes, 123);
     assert_eq!(parsed.failed_count, 1);
     assert_eq!(parsed.read_payload_ms, 4);
-    assert_eq!(parsed.worker_id.as_deref(), Some("worker-a"));
-    assert_eq!(parsed.call_seq, Some(42));
-    assert_eq!(
-        parsed
-            .phase_stats
-            .get("read_payload")
-            .map(|stats| stats.p95_ms),
-        Some(7)
-    );
     assert_eq!(parsed.results.len(), 2);
     let NativeObjectReadParseResult::Read(read) = &parsed.results[0] else {
         panic!("expected successful batch object read");
@@ -2687,7 +2547,7 @@ fn object_read_batch_maps_spilled_payload_file_and_removes_it() {
             status: "0".to_string(),
             status_success: true,
             response: AssetStudioFfiResponse::ContextReadObjects(
-                sonic_rs::from_str(r#"{"success":true,"reads":[{"success":true,"asset":{"index":0,"name":"ok","container":"assets/ok.bytes","asset_type":"TextAsset","type_id":49,"path_id":7,"size":3,"source_file":null},"payload_kind":"text_bytes","payload_len":3,"suggested_extension":".bytes","warnings":[],"phase_ms":{},"error":null,"duration_ms":1}],"warnings":[],"payload_len":3,"object_count":1,"payload_bundle_bytes":0,"failed_count":0,"read_payload_ms":1,"worker_id":null,"call_seq":null,"phase_stats":{},"error":null,"duration_ms":1}"#).unwrap(),
+                sonic_rs::from_str(r#"{"success":true,"reads":[{"success":true,"asset":{"index":0,"name":"ok","container":"assets/ok.bytes","asset_type":"TextAsset","type_id":49,"path_id":7,"size":3,"source_file":null},"payload_kind":"text_bytes","payload_len":3,"suggested_extension":".bytes","warnings":[],"phase_ms":{},"error":null,"duration_ms":1}],"warnings":[],"payload_len":3,"object_count":1,"payload_bundle_bytes":0,"failed_count":0,"read_payload_ms":1,"error":null,"duration_ms":1}"#).unwrap(),
             ),
             stderr: String::new(),
             payload: Vec::new(),
@@ -2711,7 +2571,7 @@ fn object_read_batch_maps_spilled_payload_file_and_removes_it() {
 }
 
 #[test]
-fn object_read_batch_diagnostics_record_max_phase_stats() {
+fn object_read_batch_diagnostics_record_batch_counters() {
     let asset = AssetStudioFfiAssetInfo {
         index: 0,
         name: Some("ok".to_string()),
@@ -2727,10 +2587,7 @@ fn object_read_batch_diagnostics_record_max_phase_stats() {
         written_files: Vec::new(),
         acb_sources: Vec::new(),
         pending_image_writes: Vec::new(),
-        phase_ms: HashMap::from([
-            ("read_batch.read_payload.p50".to_string(), 5),
-            ("read_batch.read_payload.p95".to_string(), 5),
-        ]),
+        phase_ms: HashMap::new(),
         skipped_object_reads: Vec::new(),
         object_read_plan: NativeObjectReadPlanStats::default(),
         worker_crash_skipped: false,
@@ -2744,19 +2601,9 @@ fn object_read_batch_diagnostics_record_max_phase_stats() {
         payload_data_bytes: 3,
         failed_count: 0,
         read_payload_ms: 3,
-        worker_id: Some("worker-a".to_string()),
-        call_seq: Some(1),
         phase_ms: HashMap::from([("read_objects".to_string(), 4)]),
-        asset_type_counts: HashMap::from([("TextAsset".to_string(), 1)]),
         payload_kind_counts: HashMap::from([("text_bytes".to_string(), 1)]),
         payload_bytes_by_kind: HashMap::from([("text_bytes".to_string(), 3)]),
-        phase_stats: HashMap::from([(
-            "read_payload".to_string(),
-            NativeBatchPhaseStats {
-                p50_ms: 2,
-                p95_ms: 9,
-            },
-        )]),
     };
 
     record_native_object_read_batch_diagnostics(&mut summary, &[&asset], &read_outputs);
@@ -2764,22 +2611,8 @@ fn object_read_batch_diagnostics_record_max_phase_stats() {
     assert_eq!(summary.object_read_plan.payload_bundle_bytes, 10);
     assert_eq!(summary.object_read_plan.read_payload_ms, 3);
     assert_eq!(
-        summary.phase_ms.get("read_batch.read_payload.p50"),
-        Some(&5)
-    );
-    assert_eq!(
-        summary.phase_ms.get("read_batch.read_payload.p95"),
-        Some(&9)
-    );
-    assert_eq!(
         summary.phase_ms.get("read_batch.phase.read_objects"),
         Some(&4)
-    );
-    assert_eq!(
-        summary
-            .phase_ms
-            .get("read_batch.asset_type_count.TextAsset"),
-        Some(&1)
     );
     assert_eq!(
         summary

--- a/src/core/export_pipeline/implementation/types.rs
+++ b/src/core/export_pipeline/implementation/types.rs
@@ -2,8 +2,6 @@ use super::*;
 
 pub(super) const NATIVE_AOT_DEFAULT_IMAGE_FORMAT: &str = "raw_rgba";
 pub(super) const NATIVE_AOT_IMAGE_SURROGATE_FORMAT: &str = "bmp";
-#[allow(dead_code)]
-pub(super) const NATIVE_AOT_FAST_IMAGE_FORMAT: &str = NATIVE_AOT_DEFAULT_IMAGE_FORMAT;
 pub(super) const NATIVE_AOT_PAYLOAD_BUNDLE_MAGIC: &[u8] = b"HARUKI_ASSET_PAYLOAD_BUNDLE_V1";
 pub(super) const NATIVE_AOT_PAYLOAD_BUNDLE_V2_MAGIC: u32 = 0x4250_4148; // HAPB
 pub(super) const NATIVE_AOT_PAYLOAD_BUNDLE_V2_VERSION: u16 = 2;
@@ -198,11 +196,7 @@ pub(super) struct NativeObjectReadBatchParseOutput {
     pub(super) payload_data_bytes: u64,
     pub(super) failed_count: usize,
     pub(super) read_payload_ms: u64,
-    pub(super) worker_id: Option<String>,
-    pub(super) call_seq: Option<u64>,
     pub(super) phase_ms: HashMap<String, u64>,
-    pub(super) asset_type_counts: HashMap<String, usize>,
     pub(super) payload_kind_counts: HashMap<String, usize>,
     pub(super) payload_bytes_by_kind: HashMap<String, u64>,
-    pub(super) phase_stats: HashMap<String, NativeBatchPhaseStats>,
 }

--- a/src/core/export_pipeline/implementation/types.rs
+++ b/src/core/export_pipeline/implementation/types.rs
@@ -137,7 +137,9 @@ pub(super) enum NativeSemanticPathClaim {
 #[derive(Debug, Clone)]
 pub(crate) struct PendingNativeImageWrite {
     pub(super) target: PathBuf,
-    pub(super) payload: Vec<u8>,
+    /// Shared slice of the read-batch payload bundle (see
+    /// `parse_payload_bundle_shared`); cloning is a refcount bump.
+    pub(super) payload: bytes::Bytes,
     pub(super) region: RegionConfig,
 }
 


### PR DESCRIPTION
## 概述

FFI payload 链路的零拷贝改造与配套工程收尾（与 Team-Haruki/AssetStudio#1 配套，两 PR 需同期合并同镜像部署——跨版本混布会退化到兼容路径）。**叠在 #42（fix/audit-improvements）之上**，#42 合并后本 PR 的 diff 即只剩本轮九个提交。

## 主要变更

**零拷贝三层（图像语料实测 1.54-1.64×，吞吐 47→80 MB/s）**
- `bytes::Bytes` 引用计数共享 payload 切片，消除每对象拷贝（`8251794`）
- 大 payload 溢写 tmpfs + `mmap` + 立即 unlink，parent 零拷贝消费（`24661c9`）
- worker 直写映射（`59b4580`）：worker 把 grouped bundle 头布局进 `/dev/shm` 映射文件，dylib 解码直接落页——worker 全程不碰 payload 字节。含加固：映射暴露前 `posix_fallocate`/`F_PREALLOCATE` 预留（tmpfs 耗尽从 SIGBUS 变 ENOSPC 优雅回退，8MB shm 实测全量导出零泄漏）、worker 启动清扫陈旧溢写文件、grow 失败兜底内联

**依赖与运行时**
- cridecoder 0.3.3 → 0.3.4（drop-in，HCA −35%/ACB 4× 微基准）（`44f65e1`）
- Dockerfile 构建阶段 SDK 9 → 10（net10 重定向配套；运行时 trixie 的 glibc 2.41 兼容 noble 产物）（`b4bec1e`）
- compose 加 `shm_size: 2gb`（Docker 默认 64MB 会丢直写映射收益）（`eae34d2`）

**契约与可观测性修复**
- 移除校验器/示例配置宣称但 dylib 从未实现的 `pjsk_model_package`/`pjsk_animation_clip_decoded`（真实路径是 haruki_3d 外部管线；按旧示例部署会静默丢 Animator/AnimationClip 数据）（`78f2e42`）
- 每对象读取失败跳过现在发 `warn!`——此前唯一静默的 skip 路径，曾隐藏 1,197 个 bundle 的 Animator 丢失（`77a0ab8`）

**清理（对抗审计驱动，净删 521 行，`15ce0e4`）**
- phase_stats p50/p95 与空诊断字段死管道全链、单对象协议变体、Direct 模式（`mode: direct` 现在配置加载即报错，`call_mode` 作为别名兼容）、死 pub API、V1 交错解析回退

## 验证

- 全 workspace 测试 + clippy 零告警（macOS/Linux）、Windows target check 零告警
- Linux trixie 生产等价容器：cn 全量 23,354 bundle × 2 遍零崩溃；三语料基准（member/music/movie）交错跑序 + 预热缓存方法学
- 强制直写回归（`HARUKI_ASSET_STUDIO_FFI_PAYLOAD_FILE_THRESHOLD=1`）、8MB shm 耗尽场景优雅回退

## 部署注意

- 与 AssetStudio 侧同镜像同期部署（Dockerfile 已按 `ASSETSTUDIO_BRANCH` 拉取，合并主线后即自动对齐）
- 生产 yaml 建议同步：删除死 `tools:` 块、`call_mode` 改 `mode`（代码侧已加别名兜底，不改也不破）

🤖 Generated with [Claude Code](https://claude.com/claude-code)