### PR TITLE
[Chore] Remove legacy AssetStudio FFI remnants

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,6 @@
 HTTP_PORT=8080
 RUST_LOG=info
 
-# Return idle AssetStudio worker memory to the OS after this many seconds.
-# Set to 0 only when permanent warm workers are intentional.
-HARUKI_ASSET_STUDIO_FFI_WORKER_IDLE_TIMEOUT_SECONDS=60
-
 # Local runtime config path override
 # HARUKI_CONFIG_PATH=./haruki-asset-configs.yaml
 

--- a/tests/dockerfile_haruki_3d.rs
+++ b/tests/dockerfile_haruki_3d.rs
@@ -13,11 +13,6 @@ fn dockerfile_keeps_haruki_3d_exporter_external() {
         "default Docker image should not clone the exporter repository"
     );
     assert!(
-        !dockerfile
-            .contains("FROM mcr.microsoft.com/dotnet/runtime:8.0-bookworm-slim AS dotnet-runtime"),
-        "default Docker image should not bundle the .NET runtime for exporter use"
-    );
-    assert!(
         !dockerfile.contains("/app/bin/Haruki-3D-Exporter"),
         "default Docker image should not install an exporter wrapper"
     );
@@ -65,7 +60,5 @@ fn container_defaults_use_the_direct_asset_engine() {
         .expect("example config should be readable");
 
     assert!(dockerfile.contains("MALLOC_ARENA_MAX=4"));
-    assert!(!dockerfile.contains("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT"));
-    assert!(!config.contains("worker_idle_timeout_seconds"));
     assert!(config.contains("read_batch_size: 64 # direct unity-rs object-read chunk size"));
 }


### PR DESCRIPTION
## Summary

- remove the obsolete AssetStudio FFI worker idle environment example
- remove stale negative assertions for the deleted .NET and worker configuration paths
- leave the directly linked unity-rs-core engine and FFmpeg media-ffi backend unchanged

## Validation

- cargo fmt --all -- --check
- cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
- cargo test --locked --workspace (167 unit tests plus all integration suites passed)
- tracked-tree search contains no legacy AssetStudio FFI, worker-pool, NativeAOT, .NET runtime, or stdio IPC references